### PR TITLE
Reduce the width of the main body to make it the same size as the gds header

### DIFF
--- a/public/styles/app.scss
+++ b/public/styles/app.scss
@@ -75,3 +75,14 @@ input:disabled {
 .govuk-form-group .govuk-details {
   margin-top: 30px;
 }
+
+.container {
+  padding-right: 0;
+  padding-left: 0;
+}
+
+@media (min-width: 1200px) {
+  .container {
+    max-width: 960px;
+  }
+}


### PR DESCRIPTION
The main body with is controlled by bootstrap classes so we need to override the widest one so it's the same width as the gds template

before

![Screenshot from 2019-05-31 14-31-01](https://user-images.githubusercontent.com/6839214/58709007-14a02380-83b1-11e9-943e-e1987203685a.png)

after

![Screenshot from 2019-05-31 14-30-39](https://user-images.githubusercontent.com/6839214/58709026-1d90f500-83b1-11e9-9176-d3bf0dd8fc32.png)
