### PR TITLE
Remove service name indentation

### DIFF
--- a/public/styles/app.scss
+++ b/public/styles/app.scss
@@ -110,3 +110,7 @@ input:disabled {
 .header-nav__link {
   margin-left: 20px;
 }
+
+.govuk-header__link--service-name {
+  margin-left: -15px;
+}


### PR DESCRIPTION
Remove service name indentation so it aligns with the left side of the app, because properly aligned elements are a wonderful thing ;)

Before:

![Screenshot from 2019-07-12 10-33-57](https://user-images.githubusercontent.com/6839214/61118944-ba0ae480-a491-11e9-888a-598fe1d897ce.png)

After:

![Screenshot from 2019-07-12 10-34-14](https://user-images.githubusercontent.com/6839214/61118977-c7c06a00-a491-11e9-999f-2c1cf6cbcf86.png)
