### PR TITLE
Fix failing test suite

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -6,6 +6,7 @@
     "react"
   ],
   "plugins": [
+    "dynamic-import-node",
     "syntax-dynamic-import",
     [
       "transform-class-properties",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1574,6 +1574,15 @@
         "babel-runtime": "^6.22.0"
       }
     },
+    "babel-plugin-dynamic-import-node": {
+      "version": "2.3.0",
+      "resolved": "http://localhost:4873/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.0.tgz",
+      "integrity": "sha512-o6qFkpeQEBxcqt0XYlWzAVxNCSCZdUgcR8IRlhD/8DylxjjO4foPcvTW0GGKa/cVt3rvxZ7o5ippJ+/0nvLhlQ==",
+      "dev": true,
+      "requires": {
+        "object.assign": "^4.1.0"
+      }
+    },
     "babel-plugin-istanbul": {
       "version": "4.1.6",
       "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "babel-eslint": "^10.0.2",
     "babel-loader": "^7.1.1",
     "babel-plugin-add-module-exports": "^0.2.1",
+    "babel-plugin-dynamic-import-node": "^2.3.0",
     "babel-plugin-react-html-attrs": "^2.1.0",
     "babel-plugin-syntax-dynamic-import": "^6.18.0",
     "babel-plugin-transform-class-properties": "^6.24.1",


### PR DESCRIPTION
DashboardPage tests were not able to run to dynamic imports in DashboardPanel (to do with `React.lazy`). Looks like we need this additional package to fix this.

There might be other ways of handling "syntax-dynamic-import" now too - we could look at this later.