### PR TITLE
Add test coverage for observer

### DIFF
--- a/app/core/util/GovUKFrontEndObserver.js
+++ b/app/core/util/GovUKFrontEndObserver.js
@@ -14,6 +14,7 @@ export default class GovUKFrontEndObserver {
 
   destroy() {
     this.observer.disconnect();
+    this.observer = null;
   }
 
 }

--- a/app/core/util/GovUKFrontEndObserver.test.js
+++ b/app/core/util/GovUKFrontEndObserver.test.js
@@ -1,0 +1,26 @@
+import GovUKFrontEndObserver from 'core/util/GovUKFrontEndObserver';
+
+describe('GovUKFrontEndObserver utility', () => {
+
+  let observer;
+
+  beforeEach(() => {
+    observer = new GovUKFrontEndObserver(document.body);
+  });
+
+  it('should create and return an observer', () => {
+    expect(observer).toBeDefined();
+  });
+
+  it('should create an internal MutationObserver', () => {
+    observer.create();
+    expect(observer.observer).toBeDefined();
+  });
+
+  it('should destroy its observer', () => {
+    observer.create();
+    observer.destroy();
+    expect(observer.observer).toBeNull();
+  });
+
+});


### PR DESCRIPTION
Can't really test the internal MutationObserver here, but this does give 100% coverage of the GovUKFrontEndObserver instance.