### PR TITLE
CSS to support interim responsive DataGrid structure

### DIFF
--- a/public/styles/app.scss
+++ b/public/styles/app.scss
@@ -83,6 +83,34 @@ input:disabled {
   }
 }
 
+.formio-component-datagrid {
+  & > table {
+    width: 100%;
+    & tr {
+      display: flex;
+      & > td:first-of-type {
+        flex-grow: 1;
+      }
+    }
+    & .govuk-select.form-control {
+      padding-right: 30px;
+    }
+    & .govuk-select {
+      height: auto;
+    }
+    & .govuk-error-message {
+      margin-top: 10px;
+    }
+    & .formio-component-number {
+      display: inline-block;
+      margin-right: 7px;
+      & input {
+        width: 55px;
+      }
+    }
+  }
+}
+
 .full-width-field .datagrid-table td {
   vertical-align: top;
   width: 100%;
@@ -98,7 +126,7 @@ input:disabled {
 }
 
 .formio-button-remove-row {
-  margin-left: 15px;
+  margin-left: 5px;
   padding-bottom: 5px;
   padding-top: 7px;
 }

--- a/public/styles/app.scss
+++ b/public/styles/app.scss
@@ -102,8 +102,6 @@ input:disabled {
       margin-top: 10px;
     }
     & .formio-component-number {
-      display: inline-block;
-      margin-right: 7px;
       & input {
         width: 55px;
       }


### PR DESCRIPTION
After discussion with Richard, we think it is best if we deploy this CSS as an interim fix for OAR and I have created a new ticket (PC-81) for a more major DataGrid component re-write to occur at a later date.

In the meantime, this CSS does not seem to break any existing DataGrids and if new ones are built using a couple of additional containers and classes (see OAR for an example) then they are much more responsive.