### PR TITLE
Fix submit button text for ManDec task

### DIFF
--- a/app/pages/task/form/components/TaskForm.jsx
+++ b/app/pages/task/form/components/TaskForm.jsx
@@ -29,7 +29,12 @@ export default class TaskForm extends React.Component {
             beforeCancel: (...args) => {
                 this.handleCancel(args);
             }
-        }
+        },
+        i18n: {
+            en: {
+                submit: 'Submit',
+            }
+        },
     };
 
     render() {


### PR DESCRIPTION
_For review once code freeze is over._

This makes the Submit button say "Submit" for all tasks. It still has different text for shift starting/editing.

I'm not exactly sure of how the i18n options are leaking out of the `ShiftForm.jsx` and into the `TaskForm.jsx`, but explicitly setting config here fixes the issue. This may affect all forms, but I believe all tasks should say "Submit" anyway.