### PR TITLE
Update attachments component

### DIFF
--- a/app/pages/task/display/component/Attachments.jsx
+++ b/app/pages/task/display/component/Attachments.jsx
@@ -1,12 +1,12 @@
 import React from "react";
 
-export default class Attachments extends React.Component {
+const Attachments = () => {
 
-    render() {
         return <div>
             <div className="data">
                 <span className="data-item bold-medium">0 attachments</span>
             </div>
         </div>
-    }
 }
+
+export default Attachments;

--- a/app/pages/task/display/component/Attachments.jsx
+++ b/app/pages/task/display/component/Attachments.jsx
@@ -1,12 +1,12 @@
-import React from "react";
+import React from 'react';
 
-const Attachments = () => {
+const Attachments = () => (
+  <div>
+    <div className="data">
+      <span className="data-item bold-medium">0 attachments</span>
+    </div>
+  </div>
+);
 
-        return <div>
-            <div className="data">
-                <span className="data-item bold-medium">0 attachments</span>
-            </div>
-        </div>
-}
 
 export default Attachments;


### PR DESCRIPTION
This PR updates the `Attachments` component to a stateless component, and lints module.

Run linter (this command runs linter for the Attachments module only):
```
npm run linter:dev -- app/pages/task/display/component/Attachments.jsx
```