### PR TITLE
Update claim component

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,6 +8,7 @@
   "parser": "babel-eslint",
   "rules": {
     "arrow-parens": [2, "as-needed"],
+    "react/jsx-fragments": 0,
     "react/jsx-one-expression-per-line": 0
   }
 }

--- a/app/pages/task/display/component/Claim.jsx
+++ b/app/pages/task/display/component/Claim.jsx
@@ -1,43 +1,63 @@
-import React from "react";
+import ImmutablePropTypes from 'react-immutable-proptypes';
 import PropTypes from 'prop-types';
-import {bindActionCreators} from "redux";
-import {connect} from "react-redux";
-import {withRouter} from "react-router-dom";
-import * as actions from "../actions";
-import {claimSuccessful} from "../selectors";
+import React from 'react';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+import { withRouter } from 'react-router-dom';
+
+// local imports
+import * as actions from '../actions';
+import { claimSuccessful } from '../selectors';
 
 export class Claim extends React.Component {
-
-
-    componentDidUpdate(prevProps) {
-        if (prevProps.claimSuccessful) {
-            this.props.history.push(`/task/${this.props.task.get('id')}`);
-        }
+  componentDidUpdate(prevProps) {
+    if (prevProps.claimSuccessful) {
+      const { history, task } = this.props;
+      history.push(`/task/${task.get('id')}`);
     }
+  }
 
-    render() {
-        const {task, kc} = this.props;
-        const userId = kc.tokenParsed.email;
-        const taskAssignee = task.get('assignee');
-        const displayButton = taskAssignee === null || (taskAssignee !== userId);
-        return displayButton ? <button id="claimTask" className="govuk-button" type="submit"
-                      onClick={() =>
-                          this.props.claimTask(this.props.task.get('id'))} >Claim</button> : <div/>
+  render() {
+    const { claimTask, task, kc } = this.props;
+    const userId = kc.tokenParsed.email;
+    const taskAssignee = task.get('assignee');
+    const displayButton = taskAssignee === null || (taskAssignee !== userId);
+
+    function renderClaimButton() {
+      if (displayButton) {
+        return (
+          <button id="claimTask" className="govuk-button" type="submit" onClick={() => claimTask(task.get('id'))}>
+            Claim
+          </button>
+        );
+      }
+      return <React.Fragment></React.Fragment>;
     }
-
+    return ({ renderClaimButton });
+  }
 }
 
 Claim.propTypes = {
-    claimTask: PropTypes.func.isRequired,
-    claimSuccessful: PropTypes.bool
+  claimTask: PropTypes.func.isRequired,
+  claimSuccessful: PropTypes.bool,
+  history: PropTypes.shape({
+    push: PropTypes.func,
+  }).isRequired,
+  kc: PropTypes.shape({
+    tokenParsed: PropTypes.shape({
+      email: PropTypes.string.isRequired,
+    }).isRequired,
+  }).isRequired,
+  task: ImmutablePropTypes.map.isRequired,
 };
 
+Claim.defaultProps = {
+  claimSuccessful: false,
+};
 
 const mapDispatchToProps = dispatch => bindActionCreators(actions, dispatch);
 
-export default withRouter(connect((state) => {
-    return {
-        kc: state.keycloak,
-        claimSuccessful: claimSuccessful(state)
-    }
-}, mapDispatchToProps)(Claim))
+export default withRouter(connect(state => ({
+  kc: state.keycloak,
+  claimSuccessful: claimSuccessful(state),
+}), mapDispatchToProps)(Claim));

--- a/app/pages/task/display/component/Claim.jsx
+++ b/app/pages/task/display/component/Claim.jsx
@@ -9,8 +9,8 @@ import {claimSuccessful} from "../selectors";
 export class Claim extends React.Component {
 
 
-    componentWillReceiveProps(nextProps) {
-        if (nextProps.claimSuccessful) {
+    componentDidUpdate(prevProps) {
+        if (prevProps.claimSuccessful) {
             this.props.history.push(`/task/${this.props.task.get('id')}`);
         }
     }


### PR DESCRIPTION
This PR updates the `Claim` component to be a stateless component, adds props validation and lints the module.

Run linter (this command runs linter for the Claim module only):

npm run linter:dev -- app/pages/task/display/component/Claim.jsx
