### PR TITLE
CO-962 - Hide Tooltip in Claim task for first and second reviews

### DIFF
--- a/app/pages/task/display/component/Actions.jsx
+++ b/app/pages/task/display/component/Actions.jsx
@@ -28,7 +28,7 @@ export default class Actions extends React.Component {
                 <div className="btn-group btn-block" role="group">
                     {actions}
                 </div>
-                {actions && actions.length >= 1 ?
+                {actions && actions.length >= 1 && !task.get('name').includes('declaration') ?
                     <details className="govuk-details">
                         <summary className="govuk-details__summary">
                             <span className="govuk-details__summary-text">


### PR DESCRIPTION
Hide actions tooltip for Man Dec review tasks because we only have the `Claim` button so the text above the button is descriptive enough.

I've not fixed additional linting for this file because it breaks the page so this will require additional work that we don't need to include in the Man Dec release