### PR TITLE
Redirect onboarded to dashboard

### DIFF
--- a/app/core/Main.jsx
+++ b/app/core/Main.jsx
@@ -22,7 +22,7 @@ const ReportPage = withOnboardingCheck(withShiftCheck(lazy(() => import('../page
 const MessagesPage = withOnboardingCheck(withShiftCheck(lazy(() => import('../pages/messages/components/MessagesPage'))));
 const CalendarPage = withOnboardingCheck(withShiftCheck(lazy(() => import('../pages/calendar/components/CalendarPage'))));
 
-const StartProcedurePage = lazy(() => import('../pages/procedures/start/components/ProcedureStartPage'));
+const StartProcedurePage = withOnboardingCheck(withShiftCheck(lazy(() => import('../pages/procedures/start/components/ProcedureStartPage'))));
 const ProcessStartPage = withOnboardingCheck(withShiftCheck(StartProcedurePage));
 const ProcessDiagramPage = withOnboardingCheck(withShiftCheck(lazy(() => import('../pages/procedures/diagram/components/ProcessDiagramPage'))));
 const TaskPage =  withOnboardingCheck(withShiftCheck(lazy(() => import('../pages/task/display/component/TaskPage'))));

--- a/app/core/Main.jsx
+++ b/app/core/Main.jsx
@@ -21,17 +21,14 @@ const YourGroupTasksContainer = withOnboardingCheck(withShiftCheck(lazy(() => im
 const ReportPage = withOnboardingCheck(withShiftCheck(lazy(() => import('../pages/reports/components/ReportPage'))));
 const MessagesPage = withOnboardingCheck(withShiftCheck(lazy(() => import('../pages/messages/components/MessagesPage'))));
 const CalendarPage = withOnboardingCheck(withShiftCheck(lazy(() => import('../pages/calendar/components/CalendarPage'))));
-
 const StartProcedurePage = withOnboardingCheck(withShiftCheck(lazy(() => import('../pages/procedures/start/components/ProcedureStartPage'))));
 const ProcessStartPage = withOnboardingCheck(withShiftCheck(StartProcedurePage));
 const ProcessDiagramPage = withOnboardingCheck(withShiftCheck(lazy(() => import('../pages/procedures/diagram/components/ProcessDiagramPage'))));
 const TaskPage =  withOnboardingCheck(withShiftCheck(lazy(() => import('../pages/task/display/component/TaskPage'))));
 
-
 //no checks required
 const UnauthorizedPage = lazy(() => import('../core/components/UnauthorizedPage'));
 const NoOpDashboardPage = lazy(() => import ('../pages/dashboard/components/NoOpDashboardPage'));
-
 
 const Main = () => (
   <main style={{paddingTop: '10px'}}>
@@ -55,7 +52,6 @@ const Main = () => (
         <Route name="No-Op Dashboard" exact path={"/noop-dashboard"} component={() => <NoOpDashboardPage/>} />
         <Redirect to={AppConstants.DASHBOARD_PATH}/>
       </Switch>
-
     </Suspense>
   </main>
 );


### PR DESCRIPTION
This PR redirects users that have already onboarded and started the shift to the dashboard page. This means that any user that has already onboarded and tries to access the `/on-board` url will be redirected to the dashboard.

If the user has onboarded but not started the shift the user will be redirected to the start shift page.