### PR TITLE
Show no border for any iframes

### DIFF
--- a/public/styles/app.scss
+++ b/public/styles/app.scss
@@ -21,6 +21,10 @@ body {
   font-family: "nta", Arial, sans-serif;
 }
 
+iframe {
+  border: 0;
+}
+
 .padding {
   padding-left: 15px;
 }


### PR DESCRIPTION
I looked at preventing the scrollbar too, but this will need a bit more attention as viewport height units look different on mobile vs desktop. Scrollbar still shows here with no iframe border. This is the only iframe in the app so far.