### PR TITLE
Allow lodev for WDS

### DIFF
--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -39,6 +39,9 @@ module.exports = webpackMerge(common, {
     new webpack.HotModuleReplacementPlugin(),
   ],
   devServer: {
+    allowedHosts: [
+      'www.lodev.xyz',
+    ],
     compress: true,
     contentBase: 'public/',
     historyApiFallback: true,


### PR DESCRIPTION
Necessary for VM connection as it is a domain expected by KC/CORS.