### PR TITLE
CO-1258 - Add defaultteam to the shift data

### DIFF
--- a/app/pages/shift/components/ShiftForm.jsx
+++ b/app/pages/shift/components/ShiftForm.jsx
@@ -99,6 +99,7 @@ export default class ShiftForm extends React.Component {
                     shiftminutes: 0,
                     shifthours: 8,
                     startdatetime: moment.utc(moment()),
+                    team: staffDetails.get('defaultteam'),
                     teamid: staffDetails.get('defaultteamid'),
                     locationid: staffDetails.get('defaultlocationid'),
                     phone: staffDetails.get('phone')


### PR DESCRIPTION
To pre-populate the `shift` form we're mapping the values returned from the db to the form fields in `ShiftForm`.

This change adds a mapping for `defaultteam` in the `staff` record to `team` in the shift form in order to pre-populate the `team` field.

