### PR TITLE
CO-1481 - Edit shift not updating local storage shift data

### DIFF
--- a/app/core/shift/epic.js
+++ b/app/core/shift/epic.js
@@ -5,6 +5,7 @@ import * as types from './actionTypes';
 import * as actions from './actions';
 import { errorObservable } from '../error/epicUtil';
 import { retry } from '../util/retry';
+import secureLocalStorage from '../../common/security/SecureLocalStorage';
 
 const shift = (email, token, workflowUrl, client) => {
   return client({
@@ -103,6 +104,7 @@ const submit = (action$, store, { client }) => action$.ofType(types.SUBMIT_VALID
         'Content-Type': 'application/json',
       },
     }).map(payload => {
+        secureLocalStorage.remove('shift');
         PubSub.publish('submission', {
             submission: true,
             autoDismiss: true,

--- a/app/core/shift/epic.test.js
+++ b/app/core/shift/epic.test.js
@@ -9,6 +9,7 @@ import 'rxjs/add/operator/mergeMap';
 import epic from './epic';
 import 'rxjs';
 import PubSub from 'pubsub-js';
+import secureLocalStorage from '../../common/security/SecureLocalStorage';
 
 jest.setTimeout(50000);
 
@@ -18,6 +19,11 @@ jest.mock('pubsub-js', () => ({
   publish: jest.fn(),
 }));
 
+jest.mock('../../common/security/SecureLocalStorage', () => {
+  return {
+    remove: jest.fn()
+  }
+});
 
 describe('shift epic', () => {
   const store = configureMockStore()({
@@ -205,6 +211,8 @@ describe('shift epic', () => {
       .subscribe(actualOutput => {
         const createActiveShift = actualOutput[0];
         expect(createActiveShift.type).toEqual('CREATE_ACTIVE_SHIFT_SUCCESS');
+        expect(secureLocalStorage.remove).toHaveBeenCalledTimes(1);
+        expect(secureLocalStorage.remove).toHaveBeenCalledWith('shift');
         done();
       });
   });


### PR DESCRIPTION
Clear shift session after shift submission so the shift session gets populated with the new details.

Also updated the unit tests.