### PR TITLE
CB-1276 Use commit sha instead of commit message

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -93,7 +93,7 @@ pipeline:
       - source: DEV_SERVICE_NOW_USERNAME
         target: SNOW_TEST_USER
     environment:
-      - SNOW_DESC=${DRONE_COMMIT_MESSAGE}
+      - SNOW_DESC=${DRONE_COMMIT_SHA}
       - SNOW_ENDPOINT=https://cto-change-dev.internal.cto-notprod.homeoffice.gov.uk/create
       - SNOW_INT_ID_FILE=/build/internal-id
       - SNOW_EXTERNAL_ID=${DRONE_REPO}:${DRONE_COMMIT_SHA}


### PR DESCRIPTION
Multiple lines in a commit comment is coming through as a map, not a string