### PR TITLE
CO-1579 - Unable to submit rejected positive declaration

### DIFF
--- a/app/pages/task/form/components/TaskForm.jsx
+++ b/app/pages/task/form/components/TaskForm.jsx
@@ -117,6 +117,11 @@ export default class TaskForm extends React.Component {
             processContext: variables,
             taskContext: task.toJS()
         };
+
+        if (submission.data.processContext) {
+            delete submission.data.processContext.submissionData;
+        }
+
         if (form) {
             const that = this;
             Formio.registerPlugin({


### PR DESCRIPTION
If the first reviewer rejects a positive declaration and the officer returns to the declarations page they are unable to continue past the first (Security clearance) page as the 'Next' button becomes disabled and displays a loading spinner. There are also 'Too much recursion' console errors displayed.

This PR removes `submissionData` from `processContext` in the submitted data, which contains a lot of data that we don't require for the current form and is causing the recursion errors.