### PR TITLE
 Remove submissionData from process variables before adding to the payload

### DIFF
--- a/app/pages/task/form/components/TaskForm.jsx
+++ b/app/pages/task/form/components/TaskForm.jsx
@@ -99,6 +99,7 @@ export default class TaskForm extends React.Component {
       } else if (variables[formVariableSubmissionName]) {
         submission = variables[formVariableSubmissionName];
       }
+      delete variables.submissionData;
     }
     if (secureLocalStorage.get(task.get('id'))) {
       submission.data = {


### PR DESCRIPTION
On the Man Dec first and second review forms we add `submissionData` as a process variable with the positive declaration data that the job holder has entered so it can be displayed back to the reviewers.

We also add the process variables to the payload as `processContext` so that data can be accessed across different forms in the same process.

Because Man Dec has several forms and a lot of data, we're getting a data recursion issue where the Make Your Declaration form can't be re-submitted after the declaration has been rejected at the first review. This is because the data gets deeply nested after adding the `submissionData` and `processContext` data for each form in the process.

This PR fixes that by removing the `submissionData` from the process after it has been used for displaying back the data and before it gets added to the `processContext` at which point it's no longer needed.