### PR TITLE
CO-1527 - Add subject to the keycloakContext

### DIFF
--- a/app/pages/forms/start/components/StartForm.jsx
+++ b/app/pages/forms/start/components/StartForm.jsx
@@ -44,7 +44,8 @@ class StartForm extends React.Component {
                 sessionId: kc.tokenParsed.session_state,
                 email: kc.tokenParsed.email,
                 givenName: kc.tokenParsed.given_name,
-                familyName: kc.tokenParsed.family_name
+                familyName: kc.tokenParsed.family_name,
+                subject: kc.subject,
             }
         };
 


### PR DESCRIPTION
We want to save the user roles to Keycloak rather than the database and to do that we need the Keycloak user id in the executor to build the request url for adding the roles.

This change adds `subject`, which is the value returned from Keycloak with the user id, to `keycloakContext` which is available during the rendering of the form and removed before submission.

There will be a new hidden field added to the onboard user form which will get this Keycloak user id and add it to the payload to make it available in the executor.