### PR TITLE
Set browser detection to be env-var-driven

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -154,8 +154,8 @@ pipeline:
         target: ANALYTICS_URL
       - source: DEV_ANALYTICS_SITE_ID
         target: ANALYTICS_SITE_ID
-      - source: DEV_WWW_BROWSER_CONFIG
-        target: BROWSER_CONFIG
+      - source: DEV_WWW_BROWSER_VERSIONS
+        target: BROWSER_VERSIONS
       - source: DEV_WWW_DETECT_BROWSER
         target: DETECT_BROWSER
     commands:
@@ -305,8 +305,8 @@ pipeline:
         target: ANALYTICS_URL
       - source: STAGING_ANALYTICS_SITE_ID
         target: ANALYTICS_SITE_ID
-      - source: STAGING_WWW_BROWSER_CONFIG
-        target: BROWSER_CONFIG
+      - source: STAGING_WWW_BROWSER_VERSIONS
+        target: BROWSER_VERSIONS
       - source: STAGING_WWW_DETECT_BROWSER
         target: DETECT_BROWSER
     commands:
@@ -389,8 +389,8 @@ pipeline:
         target: ANALYTICS_URL
       - source: PRODUCTION_ANALYTICS_SITE_ID
         target: ANALYTICS_SITE_ID
-      - source: PRODUCTION_WWW_BROWSER_CONFIG
-        target: BROWSER_CONFIG
+      - source: PRODUCTION_WWW_BROWSER_VERSIONS
+        target: BROWSER_VERSIONS
       - source: PRODUCTION_WWW_DETECT_BROWSER
         target: DETECT_BROWSER
     commands:

--- a/.drone.yml
+++ b/.drone.yml
@@ -154,6 +154,10 @@ pipeline:
         target: ANALYTICS_URL
       - source: DEV_ANALYTICS_SITE_ID
         target: ANALYTICS_SITE_ID
+      - source: DEV_WWW_BROWSER_CONFIG
+        target: BROWSER_CONFIG
+      - source: DEV_WWW_DETECT_BROWSER
+        target: DETECT_BROWSER
     commands:
       - export WWW_TAG=$${DRONE_COMMIT_SHA}
       - kd --insecure-skip-tls-verify -f kube/cert.yml
@@ -301,6 +305,10 @@ pipeline:
         target: ANALYTICS_URL
       - source: STAGING_ANALYTICS_SITE_ID
         target: ANALYTICS_SITE_ID
+      - source: STAGING_WWW_BROWSER_CONFIG
+        target: BROWSER_CONFIG
+      - source: STAGING_WWW_DETECT_BROWSER
+        target: DETECT_BROWSER
     commands:
       - export WWW_TAG=$${DRONE_COMMIT_SHA}
       - kd --insecure-skip-tls-verify -f kube/cert.yml
@@ -381,6 +389,10 @@ pipeline:
         target: ANALYTICS_URL
       - source: PRODUCTION_ANALYTICS_SITE_ID
         target: ANALYTICS_SITE_ID
+      - source: PRODUCTION_WWW_BROWSER_CONFIG
+        target: BROWSER_CONFIG
+      - source: PRODUCTION_WWW_DETECT_BROWSER
+        target: DETECT_BROWSER
     commands:
       - export WWW_TAG=$${DRONE_COMMIT_SHA}
       - kd --insecure-skip-tls-verify -f kube/cert.yml

--- a/app/core/util/browserIsSupported.js
+++ b/app/core/util/browserIsSupported.js
@@ -1,9 +1,9 @@
 import { detect } from 'detect-browser';
 
-export default (config, agentString) => {
-  if (!config || !(typeof config === 'string' && config.length)) {
+export default (versions, agentString) => {
+  if (!versions || !(typeof versions === 'string' && versions.length)) {
     throw new Error(
-      "detectBrowser expects a comma-delimited config string—e.g. 'Chrome-76.0,Edge-17.17134'",
+      "detectBrowser expects a comma-delimited versions string—e.g. 'Chrome-76.0,Edge-17.17134'",
     );
   }
 
@@ -12,7 +12,7 @@ export default (config, agentString) => {
     name: detectedBrowser.name,
     version: detectedBrowser.version.split('.'),
   };
-  const browsers = config.split(',');
+  const browsers = versions.split(',');
   let isSupported = true;
 
   browsers.forEach(browser => {

--- a/app/core/util/browserIsSupported.test.js
+++ b/app/core/util/browserIsSupported.test.js
@@ -2,62 +2,62 @@ import browserIsSupported from './browserIsSupported';
 
 describe('browserIsSupported', () => {
   // Node's jsdom is not expected among user agents...
-  const config = 'Chrome-76.0,Edge-17.17134';
+  const versions = 'Chrome-76.0,Edge-17.17134';
   const chrome =
     'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.5.3987.132 Safari/537.36';
   const edge =
     'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.102 Safari/537.36 Edge/18.18362';
   const firefox =
     'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:73.0) Gecko/20100101 Firefox/73.0';
-  it('throws error if config is not a string', () => {
-    const errorMessage = `detectBrowser expects a comma-delimited config string—e.g. '${config}'`;
+  it('throws error if versions is not a string', () => {
+    const errorMessage = `detectBrowser expects a comma-delimited versions string—e.g. '${versions}'`;
     expect(() => browserIsSupported()).toThrowError(new Error(errorMessage));
     expect(() => browserIsSupported({}, edge)).toThrow(new Error(errorMessage));
     expect(() => browserIsSupported('', edge)).toThrow(new Error(errorMessage));
-    expect(() => browserIsSupported(config, edge)).not.toThrowError();
+    expect(() => browserIsSupported(versions, edge)).not.toThrowError();
   });
 
-  it('automatically reports supported if user agent is not found in config at all', () => {
-    expect(browserIsSupported(config, firefox)).toBe(true);
+  it('automatically reports supported if user agent is not found in versions at all', () => {
+    expect(browserIsSupported(versions, firefox)).toBe(true);
   });
 
-  it('reports not supported if user agent major version < config', () => {
+  it('reports not supported if user agent major version < versions', () => {
     expect(browserIsSupported('Chrome-76.0,Edge-79.0', edge)).toBe(
       false,
     );
   });
 
-  it('reports not supported if user agent major version === config but user agent minor version < config', () => {
+  it('reports not supported if user agent major version === versions but user agent minor version < versions', () => {
     expect(
       browserIsSupported('Chrome-80.7,Edge-17.17134', chrome),
     ).toBe(false);
   });
 
-  it('reports supported if user agent major version === config and user agent minor version > config', () => {
+  it('reports supported if user agent major version === versions and user agent minor version > versions', () => {
     expect(
       browserIsSupported('Chrome-76.0,Edge-17.17135', edge),
     ).toBe(true);
   });
 
-  it('reports supported if user agent major version === config and user agent minor version === config', () => {
+  it('reports supported if user agent major version === versions and user agent minor version === versions', () => {
     expect(
       browserIsSupported('Chrome-76.0,Edge-17.17134', edge),
     ).toBe(true);
   });
 
-  it('reports supported if user agent major version > config and user agent minor version === config', () => {
+  it('reports supported if user agent major version > versions and user agent minor version === versions', () => {
     expect(
       browserIsSupported('Chrome-76.5,Edge-17.17134', chrome),
     ).toBe(true);
   });
 
-  it('reports supported if user agent major version > config and user agent minor version < config', () => {
+  it('reports supported if user agent major version > versions and user agent minor version < versions', () => {
     expect(
       browserIsSupported('Chrome-76.0,Edge-18.17133', edge),
     ).toBe(true);
   });
 
-  it('reports supported if user agent major version > config and user agent minor version > config', () => {
-    expect(browserIsSupported(config, chrome)).toBe(true);
+  it('reports supported if user agent major version > versions and user agent minor version > versions', () => {
+    expect(browserIsSupported(versions, chrome)).toBe(true);
   });
 });

--- a/app/index.jsx
+++ b/app/index.jsx
@@ -192,9 +192,6 @@ const serviceDeskUrls = {
   support: `${serviceDeskBaseUrl}/customer/portal/3`,
 };
 
-const detectBrowser = true;
-const browserConfig = 'Chrome-76.0,Edge-17.17134';
-
 if (process.env.NODE_ENV === 'production') {
   fetch('/api/config')
     .then(response => {
@@ -223,7 +220,11 @@ if (process.env.NODE_ENV === 'production') {
         analyticsSiteId: data.ANALYTICS_SITE_ID,
         apiRefUrl: data.API_REF_URI,
         serviceDeskUrls,
+        browserConfig: data.BROWSER_CONFIG,
+        detectBrowser: data.DETECT_BROWSER === 'true',
       };
+
+      const { detectBrowser, browserConfig } = store.getState().appConfig;
       if (detectBrowser && !browserIsSupported(browserConfig)) {
         unavailable(UnsupportedPage);
       } else {
@@ -250,7 +251,10 @@ if (process.env.NODE_ENV === 'production') {
     reportServiceUrl: process.env.REPORT_URI,
     apiRefUrl: process.env.API_REF_URI,
     serviceDeskUrls,
+    browserConfig: process.env.BROWSER_CONFIG,
+    detectBrowser: process.env.DETECT_BROWSER === 'true',
   };
+  const { detectBrowser, browserConfig } = store.getState().appConfig;
   if (detectBrowser && !browserIsSupported(browserConfig)) {
     unavailable(UnsupportedPage);
   } else {

--- a/app/index.jsx
+++ b/app/index.jsx
@@ -220,12 +220,12 @@ if (process.env.NODE_ENV === 'production') {
         analyticsSiteId: data.ANALYTICS_SITE_ID,
         apiRefUrl: data.API_REF_URI,
         serviceDeskUrls,
-        browserConfig: data.BROWSER_CONFIG,
+        browserVersions: data.BROWSER_VERSIONS,
         detectBrowser: data.DETECT_BROWSER === 'true',
       };
 
-      const { detectBrowser, browserConfig } = store.getState().appConfig;
-      if (detectBrowser && !browserIsSupported(browserConfig)) {
+      const { detectBrowser, browserVersions } = store.getState().appConfig;
+      if (detectBrowser && !browserIsSupported(browserVersions)) {
         unavailable(UnsupportedPage);
       } else {
         renderApp(App);
@@ -251,11 +251,11 @@ if (process.env.NODE_ENV === 'production') {
     reportServiceUrl: process.env.REPORT_URI,
     apiRefUrl: process.env.API_REF_URI,
     serviceDeskUrls,
-    browserConfig: process.env.BROWSER_CONFIG,
+    browserVersions: process.env.BROWSER_VERSIONS,
     detectBrowser: process.env.DETECT_BROWSER === 'true',
   };
-  const { detectBrowser, browserConfig } = store.getState().appConfig;
-  if (detectBrowser && !browserIsSupported(browserConfig)) {
+  const { detectBrowser, browserVersions } = store.getState().appConfig;
+  if (detectBrowser && !browserIsSupported(browserVersions)) {
     unavailable(UnsupportedPage);
   } else {
     renderApp(App);

--- a/env.yaml
+++ b/env.yaml
@@ -40,7 +40,7 @@ keys:
       webhook
   - whitelist
   - www:
-      browser_config
+      browser_versions
       detect_browser
       image
       keycloak_access_role

--- a/env.yaml
+++ b/env.yaml
@@ -40,6 +40,8 @@ keys:
       webhook
   - whitelist
   - www:
+      browser_config
+      detect_browser
       image
       keycloak_access_role
       keycloak_client_id

--- a/kube/deployment.yml
+++ b/kube/deployment.yml
@@ -77,8 +77,8 @@ spec:
           value: "{{.ANALYTICS_URL}}"
         - name: ANALYTICS_SITE_ID
           value: "{{.ANALYTICS_SITE_ID}}"
-        - name: BROWSER_CONFIG
-          value: "{{.BROWSER_CONFIG}}"
+        - name: BROWSER_VERSIONS
+          value: "{{.BROWSER_VERSIONS}}"
         - name: DETECT_BROWSER
           value: "{{.DETECT_BROWSER}}"
         securityContext:

--- a/kube/deployment.yml
+++ b/kube/deployment.yml
@@ -77,6 +77,10 @@ spec:
           value: "{{.ANALYTICS_URL}}"
         - name: ANALYTICS_SITE_ID
           value: "{{.ANALYTICS_SITE_ID}}"
+        - name: BROWSER_CONFIG
+          value: "{{.BROWSER_CONFIG}}"
+        - name: DETECT_BROWSER
+          value: "{{.DETECT_BROWSER}}"
         securityContext:
           runAsNonRoot: true
         readinessProbe:

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -34,7 +34,7 @@ module.exports = webpackMerge(common, {
         API_FORM_URI: JSON.stringify(process.env.API_FORM_URI),
         REPORT_URI: JSON.stringify(process.env.REPORT_URI),
         API_REF_URI: JSON.stringify(process.env.API_REF_URI),
-        BROWSER_CONFIG: JSON.stringify(process.env.BROWSER_CONFIG),
+        BROWSER_VERSIONS: JSON.stringify(process.env.BROWSER_VERSIONS),
         DETECT_BROWSER: JSON.stringify(process.env.DETECT_BROWSER),
       },
     }),

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -33,7 +33,9 @@ module.exports = webpackMerge(common, {
         ENGINE_URI: JSON.stringify(process.env.ENGINE_URI),
         API_FORM_URI: JSON.stringify(process.env.API_FORM_URI),
         REPORT_URI: JSON.stringify(process.env.REPORT_URI),
-        API_REF_URI: JSON.stringify(process.env.API_REF_URI)
+        API_REF_URI: JSON.stringify(process.env.API_REF_URI),
+        BROWSER_CONFIG: JSON.stringify(process.env.BROWSER_CONFIG),
+        DETECT_BROWSER: JSON.stringify(process.env.DETECT_BROWSER),
       },
     }),
     new webpack.HotModuleReplacementPlugin(),


### PR DESCRIPTION
• If `DETECT_BROWSER` is not defined, or set as anything other than 'true', then `BROWSER_CONFIG` may or may not be defined - there is no detection.
• If `DETECT_BROWSER` is defined and set as 'true', then `BROWSER_CONFIG` must also be defined (in the expected format).