### PR TITLE
Add url and realm to keycloakContext in StartForm

### DIFF
--- a/app/pages/forms/start/components/StartForm.jsx
+++ b/app/pages/forms/start/components/StartForm.jsx
@@ -46,6 +46,8 @@ class StartForm extends React.Component {
                 givenName: kc.tokenParsed.given_name,
                 familyName: kc.tokenParsed.family_name,
                 subject: kc.subject,
+                url: kc.authServerUrl,
+                realm: kc.realm,
             }
         };
 


### PR DESCRIPTION
We're using roles from Keycloak rather than than the db and so we need to change the Assign a Role form to fetch the roles from Keycloak.

In order to do this we need to add `url` and `realm` to `keycloakContext` in `StartForm` to they can be used in the form to make the API request to Keycloak.