### PR TITLE
Enhance browser detection

### DIFF
--- a/app/core/util/browserIsSupported.js
+++ b/app/core/util/browserIsSupported.js
@@ -20,9 +20,9 @@ export default (versions, agentString) => {
     const version = browser.split('-')[1].split('.');
     if (
       (userBrowser.name.match(new RegExp(name, 'i')) &&
-        userBrowser.version[0] < version[0]) ||
+        +userBrowser.version[0] < version[0]) ||
       (userBrowser.version[0] === version[0] &&
-        userBrowser.version[1] < version[1])
+        +userBrowser.version[1] < version[1])
     ) {
       isSupported = false;
     }

--- a/app/core/util/browserIsSupported.test.js
+++ b/app/core/util/browserIsSupported.test.js
@@ -22,7 +22,7 @@ describe('browserIsSupported', () => {
   });
 
   it('reports not supported if user agent major version < versions', () => {
-    expect(browserIsSupported('Chrome-76.0,Edge-79.0', edge)).toBe(
+    expect(browserIsSupported('Chrome-76.0,Edge-179.0', edge)).toBe(
       false,
     );
   });

--- a/app/core/util/browserIsSupported.test.js
+++ b/app/core/util/browserIsSupported.test.js
@@ -60,4 +60,16 @@ describe('browserIsSupported', () => {
   it('reports supported if user agent major version > versions and user agent minor version > versions', () => {
     expect(browserIsSupported(versions, chrome)).toBe(true);
   });
+
+  it('reports supported if user agent major version > versions but minor version is undefined', () => {
+    expect(browserIsSupported('Chrome-76,Edge-18.17133', chrome)).toBe(true);
+  });
+
+  it('reports supported if user agent major version === versions but minor version is undefined', () => {
+    expect(browserIsSupported('Chrome-76.0,Edge-18', edge)).toBe(true);
+  });
+
+  it('reports not supported if user agent major version < versions but minor version is undefined', () => {
+    expect(browserIsSupported('Chrome-100,Edge-18.17133', chrome)).toBe(false);
+  });
 });


### PR DESCRIPTION
The existing code hasn't so far caused any issues in production, but when browser versions exceed 99 it would, the reason being that strings are compared lexographically. This PR casts one side as a number, which is sufficient for JavaScript to perform automatic type conversion and compare both sides numerically. I've updated a test to be a scenario that would fail without this measure.

In the second commit I add tests to confirm that the code works as expected (i.e. is permissive) when minor version is omitted from the config.