### PR TITLE
Amend a couple of tests to use IE instead

### DIFF
--- a/app/core/util/browserIsSupported.test.js
+++ b/app/core/util/browserIsSupported.test.js
@@ -9,6 +9,8 @@ describe('browserIsSupported', () => {
     'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.102 Safari/537.36 Edge/18.18362';
   const firefox =
     'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:73.0) Gecko/20100101 Firefox/73.0';
+  const ie = 'Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko';
+
   it('throws error if versions is not a string', () => {
     const errorMessage = `detectBrowser expects a comma-delimited versions string—e.g. '${versions}'`;
     expect(() => browserIsSupported()).toThrowError(new Error(errorMessage));
@@ -22,39 +24,27 @@ describe('browserIsSupported', () => {
   });
 
   it('reports not supported if user agent major version < versions', () => {
-    expect(browserIsSupported('Chrome-76.0,Edge-179.0', edge)).toBe(
-      false,
-    );
+    expect(browserIsSupported('Chrome-76.0,Edge-179.0,IE-99', ie)).toBe(false);
   });
 
   it('reports not supported if user agent major version === versions but user agent minor version < versions', () => {
-    expect(
-      browserIsSupported('Chrome-80.7,Edge-17.17134', chrome),
-    ).toBe(false);
+    expect(browserIsSupported('Chrome-80.7,Edge-17.17134', chrome)).toBe(false);
   });
 
   it('reports supported if user agent major version === versions and user agent minor version > versions', () => {
-    expect(
-      browserIsSupported('Chrome-76.0,Edge-17.17135', edge),
-    ).toBe(true);
+    expect(browserIsSupported('Chrome-76.0,Edge-17.17135', edge)).toBe(true);
   });
 
   it('reports supported if user agent major version === versions and user agent minor version === versions', () => {
-    expect(
-      browserIsSupported('Chrome-76.0,Edge-17.17134', edge),
-    ).toBe(true);
+    expect(browserIsSupported('Chrome-76.0,Edge-17.17134', edge)).toBe(true);
   });
 
   it('reports supported if user agent major version > versions and user agent minor version === versions', () => {
-    expect(
-      browserIsSupported('Chrome-76.5,Edge-17.17134', chrome),
-    ).toBe(true);
+    expect(browserIsSupported('Chrome-76.5,Edge-17.17134', chrome)).toBe(true);
   });
 
   it('reports supported if user agent major version > versions and user agent minor version < versions', () => {
-    expect(
-      browserIsSupported('Chrome-76.0,Edge-18.17133', edge),
-    ).toBe(true);
+    expect(browserIsSupported('Chrome-76.0,Edge-18.17133', edge)).toBe(true);
   });
 
   it('reports supported if user agent major version > versions and user agent minor version > versions', () => {
@@ -70,6 +60,8 @@ describe('browserIsSupported', () => {
   });
 
   it('reports not supported if user agent major version < versions but minor version is undefined', () => {
-    expect(browserIsSupported('Chrome-100,Edge-18.17133', chrome)).toBe(false);
+    expect(browserIsSupported('Chrome-100,Edge-18.17133,IE-99', ie)).toBe(
+      false,
+    );
   });
 });


### PR DESCRIPTION
We're going to block Internet Explorer via env var as well, so here we say we will not allow in any version of this browser lower than 99. Also some auto-formatting.