### PR TITLE
Enable detection for chromium-webview

### DIFF
--- a/app/core/util/browserIsSupported.js
+++ b/app/core/util/browserIsSupported.js
@@ -3,7 +3,7 @@ import { detect } from 'detect-browser';
 export default (versions, agentString) => {
   if (!versions || !(typeof versions === 'string' && versions.length)) {
     throw new Error(
-      "detectBrowser expects a comma-delimited versions string—e.g. 'Chrome-76.0,Edge-17.17134'",
+      "detectBrowser expects a comma-delimited versions string—e.g. 'chrome:64.0,edge:17.17134,ie:99,chromium-webview:64.0'",
     );
   }
 
@@ -16,13 +16,13 @@ export default (versions, agentString) => {
   let isSupported = true;
 
   browsers.forEach(browser => {
-    const name = browser.split('-')[0];
-    const version = browser.split('-')[1].split('.');
+    const name = browser.split(':')[0];
+    const version = browser.split(':')[1].split('.');
     if (
-      (userBrowser.name.match(new RegExp(name, 'i')) &&
-        +userBrowser.version[0] < version[0]) ||
-      (userBrowser.version[0] === version[0] &&
-        +userBrowser.version[1] < version[1])
+      userBrowser.name === name.toLowerCase() &&
+      (+userBrowser.version[0] < version[0] ||
+        (userBrowser.version[0] === version[0] &&
+          +userBrowser.version[1] < version[1]))
     ) {
       isSupported = false;
     }

--- a/app/core/util/browserIsSupported.test.js
+++ b/app/core/util/browserIsSupported.test.js
@@ -2,7 +2,7 @@ import browserIsSupported from './browserIsSupported';
 
 describe('browserIsSupported', () => {
   // Node's jsdom is not expected among user agents...
-  const versions = 'Chrome-76.0,Edge-17.17134';
+  const versions = 'chrome:64.0,edge:17.17134,ie:99,chromium-webview:64.0';
   const chrome =
     'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.5.3987.132 Safari/537.36';
   const edge =
@@ -10,6 +10,7 @@ describe('browserIsSupported', () => {
   const firefox =
     'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:73.0) Gecko/20100101 Firefox/73.0';
   const ie = 'Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko';
+  const webview = 'Mozilla/5.0 (Linux; Android 9; SM-N950F Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/74.0.3729.136 Mobile Safari/537.36 (AirWatch Browser v7.10.7)';
 
   it('throws error if versions is not a string', () => {
     const errorMessage = `detectBrowser expects a comma-delimited versions string—e.g. '${versions}'`;
@@ -24,27 +25,27 @@ describe('browserIsSupported', () => {
   });
 
   it('reports not supported if user agent major version < versions', () => {
-    expect(browserIsSupported('Chrome-76.0,Edge-179.0,IE-99', ie)).toBe(false);
+    expect(browserIsSupported('chrome:76.0,edge:179.0,ie:99', ie)).toBe(false);
   });
 
   it('reports not supported if user agent major version === versions but user agent minor version < versions', () => {
-    expect(browserIsSupported('Chrome-80.7,Edge-17.17134', chrome)).toBe(false);
+    expect(browserIsSupported('chrome:80.7,edge:17.17134', chrome)).toBe(false);
   });
 
   it('reports supported if user agent major version === versions and user agent minor version > versions', () => {
-    expect(browserIsSupported('Chrome-76.0,Edge-17.17135', edge)).toBe(true);
+    expect(browserIsSupported('chrome:76.0,edge:17.17135', edge)).toBe(true);
   });
 
   it('reports supported if user agent major version === versions and user agent minor version === versions', () => {
-    expect(browserIsSupported('Chrome-76.0,Edge-17.17134', edge)).toBe(true);
+    expect(browserIsSupported('chrome:76.0,edge:17.17134', edge)).toBe(true);
   });
 
   it('reports supported if user agent major version > versions and user agent minor version === versions', () => {
-    expect(browserIsSupported('Chrome-76.5,Edge-17.17134', chrome)).toBe(true);
+    expect(browserIsSupported('chrome:76.5,edge:17.17134', chrome)).toBe(true);
   });
 
   it('reports supported if user agent major version > versions and user agent minor version < versions', () => {
-    expect(browserIsSupported('Chrome-76.0,Edge-18.17133', edge)).toBe(true);
+    expect(browserIsSupported('chrome:76.0,edge:18.17133', edge)).toBe(true);
   });
 
   it('reports supported if user agent major version > versions and user agent minor version > versions', () => {
@@ -52,15 +53,15 @@ describe('browserIsSupported', () => {
   });
 
   it('reports supported if user agent major version > versions but minor version is undefined', () => {
-    expect(browserIsSupported('Chrome-76,Edge-18.17133', chrome)).toBe(true);
+    expect(browserIsSupported('chrome:76,edge:18.17133', chrome)).toBe(true);
   });
 
   it('reports supported if user agent major version === versions but minor version is undefined', () => {
-    expect(browserIsSupported('Chrome-76.0,Edge-18', edge)).toBe(true);
+    expect(browserIsSupported('chrome:76.0,edge:18', edge)).toBe(true);
   });
 
   it('reports not supported if user agent major version < versions but minor version is undefined', () => {
-    expect(browserIsSupported('Chrome-100,Edge-18.17133,IE-99', ie)).toBe(
+    expect(browserIsSupported('chrome:76.0,edge:18.17133,ie:99,chromium-webview:75', webview)).toBe(
       false,
     );
   });


### PR DESCRIPTION
• Move from regex to strict identity string match for browser name
• Change name/browser separator to be colon rather than hyphen
• Add chromium-webview user agent string for tests
• Tweak logic to ensure unmentioned browsers are always admitted

This is a breaking change for the current env var structure. In other words, when this is deployed to a given env, that env must at the same time either have `DETECT_BROWSER` set to `false` or have its `BROWSER_VERSIONS` set as colon delimited - i.e.  `chrome:64.0,edge:17.17134,ie:99,chromium-webview:64.0`. I'll co-ordinate this with Dev Ops.