### PR TITLE
Support viewing of Power BI reports in UI

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "arrowParens": "avoid",
+  "singleQuote": true,
+  "trailingComma": "all"
+}

--- a/app/core/Main.jsx
+++ b/app/core/Main.jsx
@@ -57,7 +57,7 @@ const Main = () => (
         <RouteWithTitle name="Your group tasks" title={`Your team’s tasks | ${AppConstants.APP_NAME}`} exact path={AppConstants.YOUR_GROUP_TASKS_PATH} component={() => <YourGroupTaskPage />} />
         <RouteWithTitle name="Forms" title={`Operational forms | ${AppConstants.APP_NAME}`} exact path={AppConstants.FORMS_PATH} component={() =><ProceduresPage />} />
         <RouteWithTitle name="Reports" title={`Operational reports | ${AppConstants.APP_NAME}`} exact path={AppConstants.REPORTS_PATH} component={() =><ReportsPage />} />
-        <RouteWithTitle exact path={AppConstants.REPORT_PATH} title={`Operational report | ${AppConstants.APP_NAME}`} component={() => <ReportPage />} />
+        <RouteWithTitle exact path={`${AppConstants.REPORTS_PATH}/:report`} title={`Operational report | ${AppConstants.APP_NAME}`} component={() => <ReportPage />} />
         <RouteWithTitle name="Messages" title={`Operational messages | ${AppConstants.APP_NAME}`} exact path={AppConstants.MESSAGES_PATH} component={() => <MessagesPage />} />
         <RouteWithTitle name="Calendar" title={`Calendar | ${AppConstants.APP_NAME}`} exact path={AppConstants.CALENDAR_PATH} component={() => <CalendarPage />} />
         <RouteWithTitle name="Procedure Start Page" title={`Operational form | ${AppConstants.APP_NAME}`} exact path={`${AppConstants.SUBMIT_A_FORM  }/:processKey`} component={() =><ProcessStartPage />} />

--- a/app/pages/reports/components/HTMLReport.jsx
+++ b/app/pages/reports/components/HTMLReport.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Iframe from 'react-iframe';
+
+export default function HTMLReport({ htmlName, reportServiceUrl }) {
+  return (
+    <Iframe
+      url={`${reportServiceUrl}/api/reports/${htmlName}`}
+      id="report"
+      width="100%"
+      height="100%"
+      position="relative"
+      display="initial"
+      allowFullScreen
+    />
+  );
+}
+
+HTMLReport.propTypes = {
+  htmlName: PropTypes.string.isRequired,
+  reportServiceUrl: PropTypes.string.isRequired,
+};

--- a/app/pages/reports/components/HTMLReport.test.jsx
+++ b/app/pages/reports/components/HTMLReport.test.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import HTMLReport from './HTMLReport';
+
+describe('HTMLReport', () => {
+  const props = {
+    reportServiceUrl: 'http://localhost:9000',
+    htmlName: 'HTML Report',
+  };
+
+  it('renders an HTMLReport', () => {
+    const wrapper = shallow(<HTMLReport {...props} />);
+    expect(wrapper.find('Iframe').exists()).toEqual(true);
+  });
+
+  it('matches snapshot', () => {
+    const wrapper = shallow(<HTMLReport {...props} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/app/pages/reports/components/PowerBIReport.jsx
+++ b/app/pages/reports/components/PowerBIReport.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Report from 'powerbi-report-component';
+
+export default function PowerBIReport({
+  accessToken,
+  embedUrl,
+  id: embedId,
+  name: pageName,
+}) {
+  return (
+    <Report
+      {...{ accessToken, embedId, embedUrl, pageName }}
+      embedType="report"
+      permissions="Read"
+      reportMode="view"
+      style={{ width: '100%', height: '100%' }}
+      tokenType="Embed"
+    />
+  );
+}
+
+PowerBIReport.propTypes = {
+  accessToken: PropTypes.string.isRequired,
+  embedUrl: PropTypes.string.isRequired,
+  id: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
+};

--- a/app/pages/reports/components/PowerBIReport.test.jsx
+++ b/app/pages/reports/components/PowerBIReport.test.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import PowerBIReport from './PowerBIReport';
+
+describe('PowerBIReport', () => {
+  const props = {
+    accessToken: 'xxx',
+    embedUrl: 'http://www.example.com',
+    id: 'abc',
+    name: 'Power BI Report',
+  };
+
+  it('renders a PowerBIReport', () => {
+    const wrapper = shallow(<PowerBIReport {...props} />);
+    expect(wrapper.find('Report').exists()).toEqual(true);
+  });
+
+  it('matches snapshot', () => {
+    const wrapper = shallow(<PowerBIReport {...props} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/app/pages/reports/components/ReportPage.jsx
+++ b/app/pages/reports/components/ReportPage.jsx
@@ -1,17 +1,23 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import queryString from 'query-string';
 import { withRouter } from 'react-router';
-import { Link } from 'react-router-dom';
+import { Link, Redirect } from 'react-router-dom';
 import { connect } from 'react-redux';
 import AppConstants from '../../../common/AppConstants';
 import HTMLReport from './HTMLReport';
 import PowerBIReport from './PowerBIReport';
 
 export const ReportPage = ({ appConfig, location }) => {
+  if (!location.state) return <Redirect to={AppConstants.REPORTS_PATH} />;
   const { reportServiceUrl } = appConfig;
-  const params = queryString.parse(location.search);
-  const { accessToken, embedUrl, htmlName, id, name, reportType } = params;
+  const {
+    accessToken,
+    embedUrl,
+    htmlName,
+    id,
+    name,
+    reportType,
+  } = location.state;
   document.title = `${name} | ${AppConstants.APP_NAME}`;
 
   return (
@@ -48,7 +54,14 @@ ReportPage.propTypes = {
     reportServiceUrl: PropTypes.string.isRequired,
   }).isRequired,
   location: PropTypes.shape({
-    search: PropTypes.string.isRequired,
+    state: PropTypes.shape({
+      accessToken: PropTypes.string,
+      embedUrl: PropTypes.string,
+      htmlName: PropTypes.string,
+      id: PropTypes.string,
+      name: PropTypes.string.isRequired,
+      reportType: PropTypes.string,
+    }),
   }).isRequired,
 };
 

--- a/app/pages/reports/components/ReportPage.jsx
+++ b/app/pages/reports/components/ReportPage.jsx
@@ -1,53 +1,62 @@
-import React from "react";
-import Iframe from "react-iframe";
-
+import React from 'react';
+import PropTypes from 'prop-types';
 import queryString from 'query-string';
-import {withRouter} from "react-router";
-import {connect} from "react-redux";
+import { withRouter } from 'react-router';
+import { Link } from 'react-router-dom';
+import { connect } from 'react-redux';
+import AppConstants from '../../../common/AppConstants';
+import HTMLReport from './HTMLReport';
+import PowerBIReport from './PowerBIReport';
 
-export class ReportPage extends React.Component {
+export const ReportPage = ({ appConfig, location }) => {
+  const { reportServiceUrl } = appConfig;
+  const params = queryString.parse(location.search);
+  const { accessToken, embedUrl, htmlName, id, name, reportType } = params;
+  document.title = `${name} | ${AppConstants.APP_NAME}`;
 
-    render() {
+  return (
+    <div>
+      <Link
+        id="backToReports"
+        className="govuk-link govuk-back-link govuk-!-font-size-19"
+        to="/reports"
+      >
+        Back to reports
+      </Link>
 
-        const params = queryString.parse(this.props.location.search);
-        const {reportName} = params;
+      <div
+        style={{
+          display: 'flex',
+          position: 'relative',
+          margin: 'auto',
+          justifyContent: 'center',
+          height: '100vh',
+        }}
+      >
+        {reportType === 'PowerBIReport' ? (
+          <PowerBIReport {...{ accessToken, embedUrl, id, name }} />
+        ) : (
+          <HTMLReport {...{ htmlName, reportServiceUrl }} />
+        )}
+      </div>
+    </div>
+  );
+};
 
-        return (
-          <div>
-            <a
-              href="#"
-              id="backToReports"
-              style={{textDecoration: 'none'}}
-              className="govuk-link govuk-back-link govuk-!-font-size-19"
-              onClick={() => this.props.history.replace('/reports')}
-            >Back to reports
-            </a>
+ReportPage.propTypes = {
+  appConfig: PropTypes.shape({
+    reportServiceUrl: PropTypes.string.isRequired,
+  }).isRequired,
+  location: PropTypes.shape({
+    search: PropTypes.string.isRequired,
+  }).isRequired,
+};
 
-            <div style={{
-                display: 'flex',
-                position: 'relative',
-                margin: 'auto',
-                justifyContent: 'center',
-                height: '100vh'
-            }}
-            >
-              <Iframe
-                url={`${this.props.appConfig.reportServiceUrl}/api/reports/${reportName}`}
-                id="report"
-                width="100%"
-                height="100%"
-                position="relative"
-                display="initial"
-                allowFullScreen
-              />
-            </div>
-          </div>
-)
-    }
-}
-
-export default withRouter(connect(state => {
-    return {
-        appConfig: state.appConfig
-    };
-}, {})(ReportPage));
+export default withRouter(
+  connect(
+    state => ({
+      appConfig: state.appConfig,
+    }),
+    {},
+  )(ReportPage),
+);

--- a/app/pages/reports/components/ReportPage.test.jsx
+++ b/app/pages/reports/components/ReportPage.test.jsx
@@ -8,7 +8,10 @@ describe('Report Page', () => {
         reportServiceUrl: 'http://localhost:9000',
       },
       location: {
-        search: 'params',
+        state: {
+          htmlName: 'HTML Report',
+          name: 'Report',
+        },
       },
     };
     const wrapper = shallow(<ReportPage {...props} />);
@@ -21,7 +24,10 @@ describe('Report Page', () => {
         reportServiceUrl: 'http://localhost:9000',
       },
       location: {
-        search: 'params',
+        state: {
+          htmlName: 'HTML Report',
+          name: 'Report',
+        },
       },
     };
     const wrapper = shallow(<ReportPage {...props} />);
@@ -34,10 +40,38 @@ describe('Report Page', () => {
         reportServiceUrl: 'http://localhost:9000',
       },
       location: {
-        search: 'reportType=PowerBIReport',
+        state: {
+          accessToken: 'xxx',
+          embedUrl: 'http://www.example.com',
+          id: 'abc',
+          name: 'Report',
+          reportType: 'PowerBIReport',
+        },
       },
     };
     const wrapper = shallow(<ReportPage {...props} />);
     expect(wrapper.find('PowerBIReport').exists()).toEqual(true);
+  });
+
+  it('renders a redirect if no location.state found', () => {
+    const props = {
+      appConfig: {
+        reportServiceUrl: 'http://localhost:9000',
+      },
+      location: {},
+    };
+    const wrapper = shallow(<ReportPage {...props} />);
+    expect(wrapper.find('Redirect').exists()).toEqual(true);
+  });
+
+  it('matches snapshot', () => {
+    const props = {
+      appConfig: {
+        reportServiceUrl: 'http://localhost:9000',
+      },
+      location: {},
+    };
+    const wrapper = shallow(<ReportPage {...props} />);
+    expect(wrapper).toMatchSnapshot();
   });
 });

--- a/app/pages/reports/components/ReportPage.test.jsx
+++ b/app/pages/reports/components/ReportPage.test.jsx
@@ -2,20 +2,42 @@ import React from 'react';
 import { ReportPage } from './ReportPage';
 
 describe('Report Page', () => {
-  it('renders iframe for report', () => {
+  it('renders back button', () => {
     const props = {
-      location: {
-        search: '?reportName=myReport.html',
-      },
       appConfig: {
         reportServiceUrl: 'http://localhost:9000',
       },
+      location: {
+        search: 'params',
+      },
     };
-    const wrapper = shallow(<ReportPage
-      {...props}
-    />);
+    const wrapper = shallow(<ReportPage {...props} />);
     expect(wrapper.find('#backToReports').exists()).toEqual(true);
-    const iframeWrapper = wrapper.find('Iframe');
-    expect(iframeWrapper.prop('url')).toEqual(`${props.appConfig.reportServiceUrl}/api/reports/myReport.html`);
+  });
+
+  it('renders an HTMLReport for HTML reports', () => {
+    const props = {
+      appConfig: {
+        reportServiceUrl: 'http://localhost:9000',
+      },
+      location: {
+        search: 'params',
+      },
+    };
+    const wrapper = shallow(<ReportPage {...props} />);
+    expect(wrapper.find('HTMLReport').exists()).toEqual(true);
+  });
+
+  it('renders a PowerBIReport for Power BI reports', () => {
+    const props = {
+      appConfig: {
+        reportServiceUrl: 'http://localhost:9000',
+      },
+      location: {
+        search: 'reportType=PowerBIReport',
+      },
+    };
+    const wrapper = shallow(<ReportPage {...props} />);
+    expect(wrapper.find('PowerBIReport').exists()).toEqual(true);
   });
 });

--- a/app/pages/reports/components/ReportsPage.jsx
+++ b/app/pages/reports/components/ReportsPage.jsx
@@ -6,6 +6,7 @@ import { createStructuredSelector } from 'reselect';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import uuid from 'uuid';
+import _ from 'lodash';
 import { loadingReports, reports } from '../selectors';
 import DataSpinner from '../../../core/components/DataSpinner';
 import * as actions from '../actions';
@@ -36,17 +37,17 @@ export class ReportsPage extends React.Component {
                     onClick={() => {
                       const { history } = this.props;
                       history.push(
-                        (report.get('reportType') === 'PowerBIReport' &&
-                          `/report?accessToken=${report.get(
-                            'accessToken',
-                          )}&embedUrl=${report.get('embedUrl')}&id=${report.get(
-                            'id',
-                          )}&name=${report.get(
-                            'name',
-                          )}&reportType=PowerBIReport`) ||
-                          `/report?name=${report.get(
-                            'name',
-                          )}&htmlName=${report.get('htmlName')}`,
+                        `/reports/${_.kebabCase(report.get('name'))}`,
+                        (report.get('reportType') === 'PowerBIReport' && {
+                          accessToken: report.get('accessToken'),
+                          embedUrl: report.get('embedUrl'),
+                          id: report.get('id'),
+                          name: report.get('name'),
+                          reportType: report.get('reportType'),
+                        }) || {
+                          name: report.get('name'),
+                          htmlName: report.get('htmlName'),
+                        },
                       );
                     }}
                     type="submit"

--- a/app/pages/reports/components/ReportsPage.jsx
+++ b/app/pages/reports/components/ReportsPage.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import ImmutablePropTypes from 'react-immutable-proptypes';
 import { withRouter } from 'react-router-dom';
 import { createStructuredSelector } from 'reselect';
 import { bindActionCreators } from 'redux';
@@ -7,51 +8,55 @@ import { connect } from 'react-redux';
 import uuid from 'uuid';
 import { loadingReports, reports } from '../selectors';
 import DataSpinner from '../../../core/components/DataSpinner';
-import AppConstants from '../../../common/AppConstants';
 import * as actions from '../actions';
 
 export class ReportsPage extends React.Component {
   componentDidMount() {
-    this.props.fetchReportsList();
+    const { fetchReportsList } = this.props;
+    fetchReportsList();
   }
 
   render() {
-    const { loadingReports, reports } = this.props;
+    const { loadingReports: reportsLoading, reports: reportsList } = this.props;
     const items = [];
-    if (reports) {
-      reports.forEach(report => {
+    if (reportsList) {
+      reportsList.forEach(report => {
         items.push(
-          <div
-            id="report"
-            className="govuk-grid-row"
-            key={uuid()}
-          >
+          <div id="report" className="govuk-grid-row" key={uuid()}>
             <div className="govuk-grid-column-full govuk-card">
               <h4 className="govuk-heading-s">{report.get('name')}</h4>
-              <p
-                id="formDescription"
-                className="govuk-body"
-              >
+              <p id="formDescription" className="govuk-body">
                 {report.get('description')}
               </p>
-              <div
-                className="govuk-grid-row"
-              >
+              <div className="govuk-grid-row">
                 <div className="govuk-grid-column-one-third">
                   <button
                     id="actionButton"
                     className="govuk-button"
                     onClick={() => {
-                          this.props.history.push(
-                            `/report?reportName=${report.get('htmlName')}`,
-                        );}}
+                      const { history } = this.props;
+                      history.push(
+                        (report.get('reportType') === 'PowerBIReport' &&
+                          `/report?accessToken=${report.get(
+                            'accessToken',
+                          )}&embedUrl=${report.get('embedUrl')}&id=${report.get(
+                            'id',
+                          )}&name=${report.get(
+                            'name',
+                          )}&reportType=PowerBIReport`) ||
+                          `/report?name=${report.get(
+                            'name',
+                          )}&htmlName=${report.get('htmlName')}`,
+                      );
+                    }}
                     type="submit"
-                  >View
+                  >
+                    View
                   </button>
                 </div>
               </div>
             </div>
-          </div>
+          </div>,
         );
       });
     }
@@ -62,11 +67,11 @@ export class ReportsPage extends React.Component {
           <div className="govuk-grid-column-one-half">
             <span className="govuk-caption-l">Operational reports</span>
             <h2 className="govuk-heading-l">
-              {reports.size} {reports.size === 1 ? 'report' : 'reports'}
+              {reportsList.size} {reportsList.size === 1 ? 'report' : 'reports'}
             </h2>
           </div>
         </div>
-        {loadingReports ? (
+        {reportsLoading ? (
           <div
             style={{
               display: 'flex',
@@ -86,7 +91,11 @@ export class ReportsPage extends React.Component {
 
 ReportsPage.propTypes = {
   fetchReportsList: PropTypes.func.isRequired,
-  loadingReports: PropTypes.bool,
+  history: PropTypes.shape({
+    push: PropTypes.func.isRequired,
+  }).isRequired,
+  loadingReports: PropTypes.bool.isRequired,
+  reports: ImmutablePropTypes.list.isRequired,
 };
 
 const mapStateToProps = createStructuredSelector({

--- a/app/pages/reports/components/ReportsPage.test.jsx
+++ b/app/pages/reports/components/ReportsPage.test.jsx
@@ -1,68 +1,67 @@
 import React from 'react';
-import configureStore from 'redux-mock-store';
-import Immutable, { Map, List } from 'immutable';
+import Immutable, { List } from 'immutable';
 import Spinner from 'react-spinkit';
-import {MemoryRouter, Switch} from "react-router";
+import { MemoryRouter, Switch } from 'react-router';
 import AppConstants from '../../../common/AppConstants';
 import { ReportsPage } from './ReportsPage';
-import {RouteWithTitle} from "../../../core/Main";
+import { RouteWithTitle } from '../../../core/Main';
 
 describe('Reports Page', () => {
-  const initialState = {
-    'reports-page': new Map({
-      loadingReports: false,
-      reports: List([]),
-    }),
+  const initialProps = {
+    fetchReportsList: jest.fn(),
+    history: {
+      push: jest.fn(),
+    },
+    loadingReports: false,
+    reports: List([]),
   };
-  const store = configureStore()(initialState);
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
 
   it('sets document title as expected', done => {
     const props = {
-      loadingReports: false,
-      reports: List([]),
-      fetchReportsList: jest.fn(),
-      store,
+      ...initialProps,
     };
 
-   mount(<MemoryRouter initialEntries={['/reports']}>
-     <Switch>
-       <RouteWithTitle
-         name="Reports"
-         title={`Operational reports | ${AppConstants.APP_NAME}`}
-         exact
-         path={AppConstants.REPORTS_PATH}
-         component={() => <ReportsPage {...props} />}
-       />
-
-     </Switch>
-   </MemoryRouter>);
+    mount(
+      <MemoryRouter initialEntries={['/reports']}>
+        <Switch>
+          <RouteWithTitle
+            name="Reports"
+            title={`Operational reports | ${AppConstants.APP_NAME}`}
+            exact
+            path={AppConstants.REPORTS_PATH}
+            component={() => <ReportsPage {...props} />}
+          />
+        </Switch>
+      </MemoryRouter>,
+    );
     requestAnimationFrame(() => {
       expect(document.title).toBe(
-          `Operational reports | ${AppConstants.APP_NAME}`,
+        `Operational reports | ${AppConstants.APP_NAME}`,
       );
       done();
     });
-
   });
 
   it('renders data spinner', async () => {
     const props = {
+      ...initialProps,
       loadingReports: true,
-      reports: List([]),
-      fetchReportsList: jest.fn(),
-      store,
     };
-    const wrapper = await shallow(
-      <ReportsPage {...props} />,
-    );
+    const wrapper = await shallow(<ReportsPage {...props} />);
     expect(props.fetchReportsList).toBeCalled();
-    expect(wrapper.find('#reportsCountLabel').text()).toEqual('Operational reports0 reports');
+    expect(wrapper.find('#reportsCountLabel').text()).toEqual(
+      'Operational reports0 reports',
+    );
     expect(wrapper.containsMatchingElement(Spinner)).toEqual(true);
   });
 
   it('renders list of reports', async () => {
     const props = {
-      loadingReports: false,
+      ...initialProps,
       reports: Immutable.fromJS([
         {
           name: 'reportname',
@@ -70,15 +69,22 @@ describe('Reports Page', () => {
           htmlName: 'reportHtmlName',
         },
       ]),
-      fetchReportsList: jest.fn(),
-      store,
     };
-    const wrapper = await mount(
-      <ReportsPage {...props} />,
-    );
+    const wrapper = await mount(<ReportsPage {...props} />);
     expect(props.fetchReportsList).toBeCalled();
-    expect(wrapper.find('#reportsCountLabel').text()).toEqual('Operational reports1 report');
+    expect(wrapper.find('#reportsCountLabel').text()).toEqual(
+      'Operational reports1 report',
+    );
 
-    expect(wrapper.find('#report').length).toEqual(1)
+    expect(wrapper.find('#report').length).toEqual(1);
+  });
+
+  it('matches snapshot', () => {
+    const props = {
+      ...initialProps,
+      loadingReports: true,
+    };
+    const wrapper = shallow(<ReportsPage {...props} />);
+    expect(wrapper).toMatchSnapshot();
   });
 });

--- a/app/pages/reports/components/ReportsPage.test.jsx
+++ b/app/pages/reports/components/ReportsPage.test.jsx
@@ -79,6 +79,23 @@ describe('Reports Page', () => {
     expect(wrapper.find('#report').length).toEqual(1);
   });
 
+  it('triggers history.push when button is pressed', () => {
+    const props = {
+      ...initialProps,
+      reports: Immutable.fromJS([
+        {
+          name: 'reportname',
+          description: 'reportdescription',
+          htmlName: 'reportHtmlName',
+        },
+      ]),
+    };
+    const wrapper = shallow(<ReportsPage {...props} />);
+    const buttonWrapper = wrapper.find('button').first();
+    buttonWrapper.prop('onClick')();
+    expect(props.history.push).toHaveBeenCalledTimes(1);
+  });
+
   it('matches snapshot', () => {
     const props = {
       ...initialProps,

--- a/app/pages/reports/components/__snapshots__/HTMLReport.test.jsx.snap
+++ b/app/pages/reports/components/__snapshots__/HTMLReport.test.jsx.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`HTMLReport matches snapshot 1`] = `
+<Iframe
+  allowFullScreen={true}
+  display="initial"
+  height="100%"
+  id="report"
+  position="relative"
+  url="http://localhost:9000/api/reports/HTML Report"
+  width="100%"
+/>
+`;

--- a/app/pages/reports/components/__snapshots__/PowerBIReport.test.jsx.snap
+++ b/app/pages/reports/components/__snapshots__/PowerBIReport.test.jsx.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PowerBIReport matches snapshot 1`] = `
+<Report
+  accessToken="xxx"
+  embedId="abc"
+  embedType="report"
+  embedUrl="http://www.example.com"
+  pageName="Power BI Report"
+  permissions="Read"
+  reportMode="view"
+  style={
+    Object {
+      "height": "100%",
+      "width": "100%",
+    }
+  }
+  tokenType="Embed"
+/>
+`;

--- a/app/pages/reports/components/__snapshots__/ReportPage.test.jsx.snap
+++ b/app/pages/reports/components/__snapshots__/ReportPage.test.jsx.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Report Page matches snapshot 1`] = `
+<Redirect
+  to="/reports"
+/>
+`;

--- a/app/pages/reports/components/__snapshots__/ReportsPage.test.jsx.snap
+++ b/app/pages/reports/components/__snapshots__/ReportsPage.test.jsx.snap
@@ -1,0 +1,40 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Reports Page matches snapshot 1`] = `
+<div>
+  <div
+    className="govuk-grid-row"
+    id="reportsCountLabel"
+  >
+    <div
+      className="govuk-grid-column-one-half"
+    >
+      <span
+        className="govuk-caption-l"
+      >
+        Operational reports
+      </span>
+      <h2
+        className="govuk-heading-l"
+      >
+        0
+         
+        reports
+      </h2>
+    </div>
+  </div>
+  <div
+    style={
+      Object {
+        "display": "flex",
+        "justifyContent": "center",
+        "paddingTop": "20px",
+      }
+    }
+  >
+    <DataSpinner
+      message="Loading reports"
+    />
+  </div>
+</div>
+`;

--- a/app/pages/reports/reducer.js
+++ b/app/pages/reports/reducer.js
@@ -1,10 +1,10 @@
 import Immutable from 'immutable';
 import * as actions from './actionTypes';
 
-const { Map } = Immutable;
+const { List, Map } = Immutable;
 
 export const initialState = new Map({
-  reports: [],
+  reports: new List(),
   loadingReports: false,
 });
 
@@ -12,10 +12,12 @@ function reducer(state = initialState, action) {
   switch (action.type) {
     case actions.FETCH_REPORTS_LIST:
       return state.set('loadingReports', true);
-    case actions.FETCH_REPORTS_LIST_SUCCESS:
+    case actions.FETCH_REPORTS_LIST_SUCCESS: {
       const data = action.payload.entity;
-      return state.set('loadingReports', false)
+      return state
+        .set('loadingReports', false)
         .set('reports', Immutable.fromJS(data));
+    }
     case actions.FETCH_REPORTS_LIST_FAILURE:
       return state.set('loadingReports', false);
     default:

--- a/jestsetup.js
+++ b/jestsetup.js
@@ -12,3 +12,7 @@ global.MutationObserver = class {
   disconnect = jest.fn();
   observe = jest.fn((target, options) => {});
 };
+
+global.crypto = {
+  getRandomValues: jest.fn(),
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -12800,6 +12800,40 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
       "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
     },
+    "powerbi-client": {
+      "version": "2.11.0",
+      "resolved": "http://localhost:4873/powerbi-client/-/powerbi-client-2.11.0.tgz",
+      "integrity": "sha512-IvCn/VIoOg87e3SVGGgWIN1Igi+WW8byiEepAY/0FvUJ2uG7Y0bOgpfSLxwIgTWEHIMfIAZpx4NYzpiPMZibrA==",
+      "requires": {
+        "http-post-message": "^0.2",
+        "powerbi-models": "^1.3",
+        "powerbi-router": "^0.1",
+        "window-post-message-proxy": "^0.2"
+      }
+    },
+    "powerbi-models": {
+      "version": "1.3.4",
+      "resolved": "http://localhost:4873/powerbi-models/-/powerbi-models-1.3.4.tgz",
+      "integrity": "sha512-hphw7boqjh/GSTUg4xZNoUE5/SWGTKWZhDZHapl1lIsbq2uXQQWVr6k9uyvZDLfTakE4+o18SBcIQe4IRNAduQ=="
+    },
+    "powerbi-report-component": {
+      "version": "1.8.5",
+      "resolved": "http://localhost:4873/powerbi-report-component/-/powerbi-report-component-1.8.5.tgz",
+      "integrity": "sha512-T53i/pqvdnWmjW1zx3B2piSI7jcY0kkSYNfRuSqTLN2oMZJQaioK5D1FmSkFVwa1ZytApfEGq4ASYQGuD1ncug==",
+      "requires": {
+        "powerbi-client": "^2.11.0",
+        "prop-types": "^15.7.2"
+      }
+    },
+    "powerbi-router": {
+      "version": "0.1.5",
+      "resolved": "http://localhost:4873/powerbi-router/-/powerbi-router-0.1.5.tgz",
+      "integrity": "sha1-3S0tBHT4y3ZpCoX2pR2Mqf6pOjI=",
+      "requires": {
+        "es6-promise": "^3.2.1",
+        "route-recognizer": "^0.1.11"
+      }
+    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5348,6 +5348,11 @@
         "is-symbol": "^1.0.2"
       }
     },
+    "es6-promise": {
+      "version": "3.3.1",
+      "resolved": "http://localhost:4873/es6-promise/-/es6-promise-3.3.1.tgz",
+      "integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM="
+    },
     "escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -6685,7 +6690,7 @@
         },
         "fast-deep-equal": {
           "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
+          "resolved": "http://localhost:4873/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
           "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
         },
         "i18next": {
@@ -7973,6 +7978,14 @@
       "version": "0.4.10",
       "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.10.tgz",
       "integrity": "sha1-ksnBN0w1CF912zWexWzCV8u5P6Q="
+    },
+    "http-post-message": {
+      "version": "0.2.3",
+      "resolved": "http://localhost:4873/http-post-message/-/http-post-message-0.2.3.tgz",
+      "integrity": "sha1-MsVgrGFfMQp+RZ/8cSd7V5skLh4=",
+      "requires": {
+        "es6-promise": "^3.2.1"
+      }
     },
     "http-proxy": {
       "version": "1.18.0",
@@ -14289,6 +14302,11 @@
         "inherits": "^2.0.1"
       }
     },
+    "route-recognizer": {
+      "version": "0.1.11",
+      "resolved": "http://localhost:4873/route-recognizer/-/route-recognizer-0.1.11.tgz",
+      "integrity": "sha1-gQ2OVwKrtAVtbcuOhlxWhefBTrc="
+    },
     "rst-selector-parser": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/rst-selector-parser/-/rst-selector-parser-2.2.3.tgz",
@@ -17701,6 +17719,14 @@
       "dev": true,
       "requires": {
         "string-width": "^1.0.2 || 2"
+      }
+    },
+    "window-post-message-proxy": {
+      "version": "0.2.6",
+      "resolved": "http://localhost:4873/window-post-message-proxy/-/window-post-message-proxy-0.2.6.tgz",
+      "integrity": "sha512-IwNWtUWVFarBa2F9vhmfv2yr0PfPm57QuOBCw3qSLaunhD3THcHUKQ4HrJQiCuYUT7LEjhUtaoA+hrV+wQzNmQ==",
+      "requires": {
+        "es6-promise": "^3.1.2"
       }
     },
     "winston": {

--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
     "lodash": "^4.17.15",
     "moment": "^2.22.0",
     "piwik-react-router": "^0.12.1",
+    "powerbi-report-component": "^1.4.2",
     "prop-types": "^15.6.2",
     "pubsub-js": "^1.6.0",
     "query-string": "^5.1.1",


### PR DESCRIPTION
Here we receive an array of reports, as before, but we use a different component and props depending on whether the report is Power BI or custom HTML.

The reports are viewable using a new dynamic route, but we do not expose properties such as the embed token over the URL (instead we use the history object) - the reports are not supposed to be viewable over a hyperlink, but rather must be viewed via a click.

We do not cache responses in the end, because this may introduce additional complications re. authentication, and we found speed to be perfectly adequate.