### PR TITLE
Remove console messages from prod build

### DIFF
--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -30,7 +30,7 @@ module.exports = webpackMerge(common, {
       new OptimizeCSSAssetsPlugin({
         cssProcessor: cssnano,
         cssProcessorPluginOptions: {
-          preset: ['default', { discardComments: { removeAll: true }}],
+          preset: ['default', { discardComments: { removeAll: true } }],
         },
         canPrint: false,
       }),
@@ -45,7 +45,7 @@ module.exports = webpackMerge(common, {
             ascii_only: true,
           },
         },
-      })
+      }),
     ],
     nodeEnv: 'production',
     sideEffects: true,
@@ -81,9 +81,7 @@ module.exports = webpackMerge(common, {
       test: /\.js$|\.css$|\.html$/,
       threshold: 10240,
     }),
-    new CopyWebpackPlugin([
-      { from: 'server.js', to: '' },
-    ]),
+    new CopyWebpackPlugin([{ from: 'server.js', to: '' }]),
     new HtmlWebpackPlugin({
       title: 'Caching',
       template: './public/index.html',
@@ -128,7 +126,10 @@ module.exports = webpackMerge(common, {
       ios: true,
       icons: [
         {
-          src: path.join(__dirname, 'node_modules/govuk-frontend/govuk/assets/images/govuk-opengraph-image.png'),
+          src: path.join(
+            __dirname,
+            'node_modules/govuk-frontend/govuk/assets/images/govuk-opengraph-image.png',
+          ),
           size: '1200x630',
           type: 'image/png',
         },

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -38,6 +38,7 @@ module.exports = webpackMerge(common, {
         terserOptions: {
           compress: {
             comparisons: false,
+            drop_console: true,
           },
           output: {
             comments: false,


### PR DESCRIPTION
This ticket relates to removing console warnings visible in production. Most were warnings related to `moment` and I'm not able to see any of those now (I think they've been "upgraded away"), leaving only the Keycloak info messages also mentioned in the ticket.

I don't think there should be a need for console logs in production, so strip them in the Webpack build here. I'm noting on the ticket which forms I have checked and that any further warnings we notice can and should be dealt with in Dev.