### PR TITLE
Add 404 page for when forms are not found

### DIFF
--- a/app/core/components/NotFound.jsx
+++ b/app/core/components/NotFound.jsx
@@ -1,11 +1,98 @@
-import React from 'react';
+import React, { Component, Fragment } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { list } from 'react-immutable-proptypes';
+import { errors as errorsSelector } from '../error/selectors';
 
-const NotFound = ({ resource, id }) => {
-  return (
-    <div>
-      <h4 className="govuk-heading-s">{resource} with identifier {id} was not found</h4>
-    </div>
-);
+export class NotFoundPage extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      is404: null,
+    };
+  }
+
+  componentDidMount() {
+    this.checkErrors();
+  }
+
+  componentDidUpdate(prevProps) {
+    const { errors } = this.props;
+    if (errors !== prevProps.errors) {
+      this.checkErrors();
+    }
+  }
+
+  checkErrors() {
+    const { errors } = this.props;
+    this.setState({
+      is404: errors.some(error => error.get('status') === 404),
+    });
+  }
+
+  render() {
+    const { resource, id } = this.props;
+    const { is404 } = this.state;
+    switch (is404) {
+      case true:
+        return (
+          <Fragment>
+            <h2 className="govuk-heading-l govuk-!-margin-top-6">
+              Page not found
+            </h2>
+            <p className="govuk-body">
+              If you typed the web address, check it is correct.
+            </p>
+            <p className="govuk-body">
+              If you pasted the web address, check you copied the entire
+              address.
+            </p>
+            <p className="govuk-body">
+              If you&rsquo;re looking for a form then{' '}
+              <a href="/forms">view the full available list here</a>.
+            </p>
+            <p className="govuk-body">
+              To find something else then{' '}
+              <a href="/dashboard">go to the COP dashboard</a>.
+            </p>
+            <p className="govuk-body">
+              If the web address is correct or you selected a link or button,{' '}
+              <a
+                href="https://support.cop.homeoffice.gov.uk/servicedesk/customer/portal/3"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                contact the COP support team
+              </a>{' '}
+              to report a bug.
+            </p>
+          </Fragment>
+        );
+
+      case false:
+        return (
+          <div>
+            <h4 className="govuk-heading-s">
+              {resource} with identifier {id} was not found
+            </h4>
+          </div>
+        );
+
+      default:
+        return null;
+    }
+  }
+}
+NotFoundPage.propTypes = {
+  errors: list.isRequired,
+  resource: PropTypes.string.isRequired,
+  id: PropTypes.string,
 };
 
-export default NotFound;
+NotFoundPage.defaultProps = {
+  id: '',
+};
+
+export default connect(state => ({
+  errors: errorsSelector(state),
+}))(NotFoundPage);

--- a/app/core/components/NotFound.test.jsx
+++ b/app/core/components/NotFound.test.jsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import configureStore from 'redux-mock-store';
+import { Map, List } from 'immutable';
+import NotFound, { NotFoundPage } from './NotFound';
+
+describe('NotFound page', () => {
+  const props = {
+    errors: List([
+      Map({
+        status: 500,
+        message: 'test',
+      }),
+    ]),
+    resource: 'Form',
+  };
+
+  it('renders without crashing', () => {
+    const wrapper = mount(<NotFoundPage {...props} />);
+    expect(wrapper.exists()).toBe(true);
+  });
+  it('renders standard notice if not 404 error', () => {
+    const wrapper = shallow(<NotFoundPage {...props} />);
+    expect(wrapper.find('h4').text()).toBe(
+      'Form with identifier  was not found',
+    );
+  });
+
+  it('renders 404 page if 404 error', () => {
+    const wrapper = shallow(<NotFoundPage {...props} />);
+    wrapper.setProps({
+      ...props,
+      errors: List([
+        Map({
+          status: 404,
+          message: 'test',
+        }),
+      ]),
+    });
+    expect(wrapper.find('h2').text()).toBe('Page not found');
+  });
+
+  it('matches snapshot', () => {
+    const wrapper = shallow(<NotFoundPage {...props} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+});
+
+describe('NotFound container', () => {
+  it('receives state as expected', () => {
+    const store = configureStore()({
+      'error-page': Map({
+        errors: List([
+          Map({
+            status: 404,
+            message: 'test',
+          }),
+        ]),
+      }),
+    });
+    const wrapper = shallow(<NotFound store={store} resource="Form" />);
+    expect(wrapper.exists()).toBe(true);
+  });
+});

--- a/app/core/components/__snapshots__/NotFound.test.jsx.snap
+++ b/app/core/components/__snapshots__/NotFound.test.jsx.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NotFound page matches snapshot 1`] = `
+<div>
+  <h4
+    className="govuk-heading-s"
+  >
+    Form
+     with identifier 
+     was not found
+  </h4>
+</div>
+`;

--- a/app/core/error/component/ErrorHandlingComponent.jsx
+++ b/app/core/error/component/ErrorHandlingComponent.jsx
@@ -109,7 +109,11 @@ export class ErrorHandlingComponent extends React.Component {
   }
 
   render() {
-    return (
+    const { errors: ers, children } = this.props;
+    const is404 = ers && ers.size ?
+      ers.find(error => error.get('status') === 404) !== undefined
+      : false;
+    return is404 ? children : (
       <React.Fragment>
         <ErrorPanel {...this.props} />
         <FormErrorPanel errors={this.state.formErrors} />
@@ -120,6 +124,10 @@ export class ErrorHandlingComponent extends React.Component {
 }
 
 ErrorHandlingComponent.propTypes = {
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node
+  ]).isRequired,
   log: PropTypes.func.isRequired,
   hasError: PropTypes.bool.isRequired,
   history: PropTypes.object.isRequired,

--- a/app/pages/forms/start/components/FormsStartPage.test.jsx
+++ b/app/pages/forms/start/components/FormsStartPage.test.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
-import Immutable from 'immutable';
+import Immutable, { Map, List } from 'immutable';
+import configureStore from 'redux-mock-store';
+import { Provider } from 'react-redux';
 import { ProcessStartPage } from './FormsStartPage';
 import secureLocalStorage from '../../../../common/security/SecureLocalStorage';
 import AppConstants from '../../../../common/AppConstants';
@@ -101,7 +103,7 @@ describe('Submit a form page', () => {
     expect(wrapper.find('.loader-message').text()).toEqual('Loading form...');
   });
 
-  it('displays resource not found if form is missing', async () => {
+  it('displays Not Found component if form is missing', async () => {
     const props = {
       loadingForm: false,
       submissionStatus: null,
@@ -132,19 +134,27 @@ describe('Submit a form page', () => {
     };
     const fetchProcessDefinition = jest.fn();
     const clearProcessDefinition = jest.fn();
-
+    const store = configureStore()({
+      'error-page': Map({
+        errors: List([
+          Map({
+            status: 404,
+            message: 'test',
+          }),
+        ]),
+      }),
+    });
     const wrapper = await mount(
-      <ProcessStartPage
-        {...props}
-        clearProcessDefinition={clearProcessDefinition}
-        fetchProcessDefinition={fetchProcessDefinition}
-      />,
+      <Provider store={store}>
+        <ProcessStartPage
+          {...props}
+          clearProcessDefinition={clearProcessDefinition}
+          fetchProcessDefinition={fetchProcessDefinition}
+        />
+      </Provider>,
     );
     expect(fetchProcessDefinition).toHaveBeenCalled();
-
-    expect(wrapper.find('div').text()).toEqual(
-      'Form with identifier formKey was not found',
-    );
+    expect(wrapper.find('NotFoundPage')).toHaveLength(1);
   });
 
   it('sets document title as expected when processDefinition loaded', () => {

--- a/app/pages/tasks/components/YourGroupTasks.test.jsx
+++ b/app/pages/tasks/components/YourGroupTasks.test.jsx
@@ -3,11 +3,11 @@ import configureStore from 'redux-mock-store';
 import Immutable, { Map } from 'immutable';
 import moment from 'moment';
 import { createMemoryHistory } from 'history';
-import {MemoryRouter, Router, Switch} from 'react-router-dom';
+import { MemoryRouter, Router, Switch } from 'react-router-dom';
 import { Provider } from 'react-redux';
 import AppConstants from '../../../common/AppConstants';
 import { YourGroupTasksContainer } from './YourGroupTasksContainer';
-import {RouteWithTitle} from "../../../core/Main";
+import { RouteWithTitle } from '../../../core/Main';
 
 jest.useFakeTimers();
 
@@ -15,7 +15,9 @@ describe('YourGroupTasksContainer Page', () => {
   const mockStore = configureStore();
   let store;
   const date = moment();
-  const yourGroupTasks ={
+  const history = createMemoryHistory('/your-tasks');
+  const yourGroupTasks = {
+    history,
     isFetchingTasks: false,
     sortValue: 'sort=due,desc',
     total: 1,
@@ -42,14 +44,15 @@ describe('YourGroupTasksContainer Page', () => {
         },
       },
     });
-    window.matchMedia = window.matchMedia
-    || function matchMedia() {
-      return {
-        matches: true,
-        addListener() {},
-        removeListener() {},
+    window.matchMedia =
+      window.matchMedia ||
+      function matchMedia() {
+        return {
+          matches: true,
+          addListener() {},
+          removeListener() {},
+        };
       };
-    };
   });
   afterEach(() => {
     window.matchMedia = null;
@@ -57,8 +60,11 @@ describe('YourGroupTasksContainer Page', () => {
   const fetchYourGroupTasks = jest.fn();
 
   it('sets document title as expected', done => {
+    const history = createMemoryHistory('/your-tasks');
     const props = {
       isFetchingTasks: true,
+      groupYourTeamTasks: jest.fn(),
+      history,
       kc: {
         tokenParsed: {
           email: 'email',
@@ -66,35 +72,38 @@ describe('YourGroupTasksContainer Page', () => {
       },
     };
 
-    mount(<MemoryRouter initialEntries={['/your-group-tasks']}>
-      <Switch>
-        <RouteWithTitle
-          name="Your group tasks"
-          title={`Your team’s tasks | ${AppConstants.APP_NAME}`}
-          exact
-          path={AppConstants.YOUR_GROUP_TASKS_PATH}
-          component={() => (
-            <YourGroupTasksContainer
-              store={store}
-              {...props}
-              fetchYourGroupTasks={fetchYourGroupTasks}
-            />
-)}
-        />
-
-      </Switch>
-    </MemoryRouter>);
+    mount(
+      <MemoryRouter initialEntries={['/your-group-tasks']}>
+        <Switch>
+          <RouteWithTitle
+            name="Your group tasks"
+            title={`Your team’s tasks | ${AppConstants.APP_NAME}`}
+            exact
+            path={AppConstants.YOUR_GROUP_TASKS_PATH}
+            component={() => (
+              <YourGroupTasksContainer
+                store={store}
+                {...props}
+                fetchYourGroupTasks={fetchYourGroupTasks}
+              />
+            )}
+          />
+        </Switch>
+      </MemoryRouter>,
+    );
     requestAnimationFrame(() => {
       expect(document.title).toBe(
-          `Your team’s tasks | ${AppConstants.APP_NAME}` ,
+        `Your team’s tasks | ${AppConstants.APP_NAME}`,
       );
       done();
     });
   });
 
   it('renders data spinner while loading tasks', async () => {
+    const history = createMemoryHistory('/your-tasks');
     const props = {
       isFetchingTasks: true,
+      history,
       kc: {
         tokenParsed: {
           email: 'email',
@@ -196,16 +205,16 @@ describe('YourGroupTasksContainer Page', () => {
       filterValue: 'TEST',
       total: 1,
       tasks: Immutable.fromJS([
-      {
-        task: {
-          id: 'id',
-          name: 'test',
-          priority: 1000,
-          due: date,
-          created: date,
+        {
+          task: {
+            id: 'id',
+            name: 'test',
+            priority: 1000,
+            due: date,
+            created: date,
+          },
         },
-      },
-    ]),
+      ]),
     };
 
     const wrapper = await mount(
@@ -255,7 +264,7 @@ describe('YourGroupTasksContainer Page', () => {
             created: date,
           },
         },
-      ])
+      ]),
     };
 
     const wrapper = await mount(

--- a/app/pages/tasks/components/YourTasks.test.jsx
+++ b/app/pages/tasks/components/YourTasks.test.jsx
@@ -1,6 +1,6 @@
 import moment from 'moment';
 import { createMemoryHistory } from 'history';
-import {MemoryRouter, Router, Switch} from 'react-router-dom';
+import { MemoryRouter, Router, Switch } from 'react-router-dom';
 import React from 'react';
 import configureStore from 'redux-mock-store';
 import Immutable, { Map } from 'immutable';
@@ -8,7 +8,7 @@ import AppConstants from '../../../common/AppConstants';
 import { YourTasksContainer } from './YourTasksContainer';
 import YourTasks from './YourTasks';
 import TaskUtils from './TaskUtils';
-import {RouteWithTitle} from "../../../core/Main";
+import { RouteWithTitle } from '../../../core/Main';
 
 jest.useFakeTimers();
 
@@ -90,14 +90,15 @@ describe('YourTasks Page', () => {
     store = configureStore()({
       'tasks-page': new Map({}),
     });
-    window.matchMedia = window.matchMedia
-    || function matchMedia() {
-      return {
-        matches: true,
-        addListener() {},
-        removeListener() {},
+    window.matchMedia =
+      window.matchMedia ||
+      function matchMedia() {
+        return {
+          matches: true,
+          addListener() {},
+          removeListener() {},
+        };
       };
-    };
   });
   afterEach(() => {
     window.matchMedia = null;
@@ -109,6 +110,8 @@ describe('YourTasks Page', () => {
     const props = {
       filterTasksByName: jest.fn(),
       goToTask: jest.fn(),
+      groupYourTasks: jest.fn(),
+      resetYourTasks: jest.fn(),
       sortYourTasks: jest.fn(),
       yourTasks: taskUtil.applyGrouping('category', [
         {
@@ -126,22 +129,21 @@ describe('YourTasks Page', () => {
       ]),
     };
 
-    mount(<MemoryRouter initialEntries={['/your-tasks']}>
-      <Switch>
-        <RouteWithTitle
-          name="Your tasks"
-          title={`Your tasks | ${AppConstants.APP_NAME}`}
-          exact
-          path={AppConstants.YOUR_TASKS_PATH}
-          component={() => <YourTasks {...props} />}
-        />
-
-      </Switch>
-    </MemoryRouter>);
+    mount(
+      <MemoryRouter initialEntries={['/your-tasks']}>
+        <Switch>
+          <RouteWithTitle
+            name="Your tasks"
+            title={`Your tasks | ${AppConstants.APP_NAME}`}
+            exact
+            path={AppConstants.YOUR_TASKS_PATH}
+            component={() => <YourTasks {...props} />}
+          />
+        </Switch>
+      </MemoryRouter>,
+    );
     requestAnimationFrame(() => {
-      expect(document.title).toBe(
-          `Your tasks | ${AppConstants.APP_NAME}`,
-      );
+      expect(document.title).toBe(`Your tasks | ${AppConstants.APP_NAME}`);
       done();
     });
   });
@@ -151,13 +153,16 @@ describe('YourTasks Page', () => {
       appConfig: {
         uiEnvironment: 'local',
       },
+      groupYourTasks: jest.fn(),
+      history: createMemoryHistory('/task'),
       kc: {
         tokenParsed: {
           email: 'test@tes.com',
         },
         token: 'token',
       },
-      isFetchingTasks: true
+      isFetchingTasks: true,
+      resetYourTasks: jest.fn(),
     };
     const wrapper = await mount(
       <YourTasksContainer
@@ -177,13 +182,16 @@ describe('YourTasks Page', () => {
       appConfig: {
         uiEnvironment: 'local',
       },
+      groupYourTasks: jest.fn(),
+      history: createMemoryHistory('/task'),
       kc: {
         tokenParsed: {
           email: 'test@tes.com',
         },
         token: 'token',
       },
-      ...yourTasks
+      resetYourTasks: jest.fn(),
+      ...yourTasks,
     };
     const wrapper = await mount(
       <YourTasksContainer
@@ -207,12 +215,15 @@ describe('YourTasks Page', () => {
       appConfig: {
         uiEnvironment: 'local',
       },
+      groupYourTasks: jest.fn(),
+      history: createMemoryHistory('/task'),
       kc: {
         tokenParsed: {
           email: 'test@tes.com',
         },
         token: 'token',
       },
+      resetYourTasks: jest.fn(),
       ...yourTasks,
     };
     const wrapper = await mount(
@@ -248,12 +259,15 @@ describe('YourTasks Page', () => {
       appConfig: {
         uiEnvironment: 'local',
       },
+      groupYourTasks: jest.fn(),
+      history: createMemoryHistory('/task'),
       kc: {
         tokenParsed: {
           email: 'test@tes.com',
         },
         token: 'token',
       },
+      resetYourTasks: jest.fn(),
       ...yourTasks,
     };
     const wrapper = await mount(
@@ -297,10 +311,12 @@ describe('YourTasks Page', () => {
         },
         token: 'token',
       },
+      groupYourTasks: jest.fn(),
       history,
       isFetchingTasks: false,
       sortValue: 'sort=due,desc',
       filterValue: 'TEST',
+      resetYourTasks: jest.fn(),
       total: 1,
       tasks: Immutable.fromJS([
         {


### PR DESCRIPTION
This handles 404 errors and instead of showing error notices in this case shows a more user-friendly 404 page. (Also some adding of props for tests and linting.)