### PR TITLE
Copy favicon images to dist and reference in index.html

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -8,10 +8,10 @@
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <meta name="theme-color" content="blue"/>
-  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
-  <link rel="manifest" href="/site.webmanifest">
+  <link rel="apple-touch-icon" sizes="180x180" href="assets/images/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="assets/images/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="assets/images/favicon-16x16.png">
+  <link rel="manifest" href="assets/images/site.webmanifest">
   <meta property="og:image" content="/assets/images/govuk-opengraph-image.png">
   <script>
     if (typeof TextEncoder === "undefined") {

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -43,6 +43,7 @@ module.exports = {
     }),
     new CopyWebpackPlugin([
       { from: 'node_modules/govuk-frontend/govuk/assets', to: 'assets' },
+      { from: 'public', to: 'assets/images', force: true },
     ]),
     new webpack.ProvidePlugin({
       $: 'jquery',


### PR DESCRIPTION
Many thanks to @shepda for spotting the probable underlying issue here (favicons needing to be copied into the `dist` dir on build and referenced there!). We'll try this in browsers on Dev.