### PR TITLE
Enable custom event for form cancellation

### DIFF
--- a/app/pages/forms/start/components/FormsStartPage.jsx
+++ b/app/pages/forms/start/components/FormsStartPage.jsx
@@ -88,12 +88,15 @@ export class ProcessStartPage extends React.Component {
   }
 
   handleCustomEvent = event => {
+    const { history, processDefinition: pd } = this.props;
     switch (event.type) {
       case 'cancel':
-        this.secureLocalStorage.remove(
-          this.props.processDefinition.getIn(['process-definition', 'id']),
-        );
-        this.props.history.replace(AppConstants.DASHBOARD_PATH);
+        this.secureLocalStorage.remove(pd.getIn(['process-definition', 'id']));
+        history.replace(AppConstants.DASHBOARD_PATH);
+        break;
+      case 'cancel-form':
+        this.secureLocalStorage.remove(pd.getIn(['process-definition', 'id']));
+        history.replace(AppConstants.FORMS_PATH);
         break;
       case 'save-draft':
         break;
@@ -323,6 +326,9 @@ ProcessStartPage.propTypes = {
   fetchForm: PropTypes.func,
   fetchProcessDefinition: PropTypes.func.isRequired,
   clearProcessDefinition: PropTypes.func.isRequired,
+  history: PropTypes.shape({
+    replace: PropTypes.func.isRequired,
+  }).isRequired,
   submit: PropTypes.func,
   processDefinition: ImmutablePropTypes.map,
   submissionStatus: PropTypes.string,


### PR DESCRIPTION
This is for a request from Richard that the user be able to cancel specifically when on the User Profile form. When a `cancel-form` event is dispatched from a form, we'll return the user to the forms list page. Also a couple of linting fixes in here.