### PR TITLE
Add css to preserve linebreaks in textareas

### DIFF
--- a/public/styles/app.scss
+++ b/public/styles/app.scss
@@ -101,3 +101,8 @@ input:disabled {
 .not-over-due-date {
   color: #00703c !important;
 }
+
+/* Preserve whitespace in details textareas */
+div[ref="details"] div[ref="input"] {
+  white-space: pre-wrap;
+}


### PR DESCRIPTION
AC: line breaks in _details_ textareas need to be retained so when we display them back it's not one blob of text

To test:

- submit an Intelligence Referral form, make sure for details you enter multiple paragraphs with line breaks
- view the case
- view the intel report within the case 
- go to the details section
- you should see the text as you typed it originally, with line breaks

