### PR TITLE
COP-1163 Update navigation

### DIFF
--- a/app/common/AppConstants.js
+++ b/app/common/AppConstants.js
@@ -31,5 +31,9 @@ export default class AppConstants {
 
     static CASES_PATH = "/cases";
 
+    static MY_PROFILE_PATH = 'submit-a-form/edit-your-profile';
+
+    static SUPPORT_PATH = 'https://support.cop.homeoffice.gov.uk/servicedesk/customer/portal/3'
+
     static REFRESH_TIMEOUT = 300000;
 }

--- a/app/core/components/Header.jsx
+++ b/app/core/components/Header.jsx
@@ -2,96 +2,112 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
-import {withRouter} from 'react-router-dom';
+import { withRouter, Link } from 'react-router-dom';
 
 // local imports
 import AppConstants from "../../common/AppConstants";
 import secureLocalStorage from '../../common/security/SecureLocalStorage';
-import SkipLink from './SkipLink';
 
 
 export class Header extends React.Component {
-    constructor(props) {
-        super(props);
-        this.secureLocalStorage = secureLocalStorage;
-        this.logout = this.logout.bind(this);
-        this.dashboard = this.dashboard.bind(this);
-    }
+  constructor(props) {
+      super(props);
+      this.secureLocalStorage = secureLocalStorage;
+      this.logout = this.logout.bind(this);
+      this.dashboard = this.dashboard.bind(this);
+      this.state = {
+        navData: [
+          {
+            urlStem: AppConstants.DASHBOARD_PATH,
+            text: 'Home',
+            active: true,
+          },
+          {
+            urlStem: AppConstants.YOUR_TASKS_PATH,
+            text: 'Tasks',
+            active: false,
+          },
+        ]
+      }
+  }
 
-    dashboard(event) {
-        event.preventDefault();
-        this.props.history.push(AppConstants.DASHBOARD_PATH);
-    }
+  setActivePage(url) {
+    const tempArr = [...this.state.navData];
+    tempArr.map(elem => {
+      const currentUrl = !url ? this.location.pathname : url;
+      if (currentUrl === elem.urlStem) {
+        elem.active = true;
+        document.activeElement.blur();
+      } else {
+        elem.active = false;
+      }
+    });
+    this.setState({ navData: tempArr });
+  };
 
-    logout(event) {
-        event.preventDefault();
-        this.secureLocalStorage.removeAll();
-        this.props.kc.logout();
-    }
+  dashboard(event) {
+      event.preventDefault();
+      this.props.history.push(AppConstants.DASHBOARD_PATH);
+  }
 
-    render() {
-        return (
-          <header className="govuk-header" role="banner" data-module="header">
-            <SkipLink />
-            <div className="govuk-header__container govuk-width-container">
-              <div className="govuk-header__content" style={{width: '100%'}}>
-                <div className="govuk-grid-row">
-                  <div className="govuk-grid-column-one-half">
-                    <a
-                      id="dashboard"
-                      href={AppConstants.DASHBOARD_PATH}
-                      onClick={event => this.dashboard(event)}
-                      className="govuk-header__link govuk-header__link--service-name"
-                    >{AppConstants.APP_NAME}
-                    </a>
-                  </div>
-                  <div className="govuk-grid-column-one-half header-nav">
-                    <a
-                      id="profile"
-                      href={`${AppConstants.SUBMIT_A_FORM}/edit-your-profile`}
-                      onClick={event => {
-                                    event.preventDefault();
-                                    this.props.history.replace(`${AppConstants.SUBMIT_A_FORM}/edit-your-profile`)
-                                }}
-                      className="govuk-header__link header-nav__link"
-                    >My profile
-                    </a>
-                    <a
-                      id="support"
-                      className="govuk-header__link header-nav__link"
-                      href={`${this.props.appConfig.serviceDeskUrls.support}`}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >Support
-                    </a>
-                    <a
-                      id="logout"
-                      href="/logout"
-                      onClick={this.logout}
-                      className="govuk-header__link header-nav__link"
-                    >Sign out
-                    </a>
-                  </div>
-                </div>
-              </div>
+  logout(event) {
+      event.preventDefault();
+      this.secureLocalStorage.removeAll();
+      this.props.kc.logout();
+  }
+
+  render() {
+      return (
+
+        <header className="govuk-header " role="banner" data-module="header">
+          <div className="govuk-header__container govuk-width-container">
+            <div className="govuk-header__content">
+              <a 
+                id='serviceName'
+                href={AppConstants.DASHBOARD_PATH}
+                className="govuk-header__link govuk-header__link--service-name"
+              >
+                {AppConstants.APP_NAME}
+              </a>
+              {/* <button type="button" className="govuk-header__menu-button js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button> */}
+              <nav>
+                
+                <ul id="navigation" className="govuk-header__navigation " aria-label="Top Level Navigation">
+                  {(this.state.navData).map(elem => {
+                  const activeState = elem.active === true ? 'govuk-header__navigation-item govuk-header__navigation-item--active' : 'govuk-header__navigation-item';
+                  return (
+                    <li className={activeState} key={elem.urlStem}>
+                      <Link to={elem.urlStem} className="govuk-header__link" onClick={() => this.setActivePage(elem.urlStem)}>{elem.text}</Link>
+                    </li>
+                  );
+                })}
+
+                  <li className="govuk-header__navigation-item">
+                    <a className="govuk-header__link" onClick={this.logout}>Sign out</a>
+                  </li>
+                </ul>
+
+              </nav>
             </div>
-          </header>
-);
+          </div>
+        </header>
+      );
     }
-}
+  }
 
 Header.propTypes = {
-    history: PropTypes.shape({
-        push: PropTypes.func,
-    }).isRequired,
-    kc: PropTypes.shape({
-        logout: PropTypes.func,
-    }).isRequired,
+history: PropTypes.shape({
+    push: PropTypes.func,
+}).isRequired,
+kc: PropTypes.shape({
+    logout: PropTypes.func,
+}).isRequired,
 };
 
 const mapDispatchToProps = dispatch => bindActionCreators({}, dispatch);
 
 export default withRouter(connect(state => ({
-    kc: state.keycloak,
-    appConfig: state.appConfig,
+kc: state.keycloak,
+appConfig: state.appConfig,
 }), mapDispatchToProps)(Header));
+

--- a/app/core/components/Header.jsx
+++ b/app/core/components/Header.jsx
@@ -7,6 +7,7 @@ import { withRouter, Link } from 'react-router-dom';
 // local imports
 import AppConstants from "../../common/AppConstants";
 import secureLocalStorage from '../../common/security/SecureLocalStorage';
+import './Header.scss';
 
 
 export class Header extends React.Component {
@@ -25,6 +26,26 @@ export class Header extends React.Component {
           {
             urlStem: AppConstants.YOUR_TASKS_PATH,
             text: 'Tasks',
+            active: false,
+          },
+          {
+            urlStem: AppConstants.FORMS_PATH,
+            text: 'Forms',
+            active: false,
+          },
+          {
+            urlStem: AppConstants.CASES_PATH,
+            text: 'Cases',
+            active: false,
+          },
+          {
+            urlStem: AppConstants.REPORTS_PATH,
+            text: 'Reports',
+            active: false,
+          },
+          {
+            urlStem: AppConstants.MY_PROFILE_PATH,
+            text: 'My profile',
             active: false,
           },
         ]
@@ -62,17 +83,16 @@ export class Header extends React.Component {
         <header className="govuk-header " role="banner" data-module="header">
           <div className="govuk-header__container govuk-width-container">
             <div className="govuk-header__content">
-              <a 
+              <Link 
                 id='serviceName'
-                href={AppConstants.DASHBOARD_PATH}
+                to={AppConstants.DASHBOARD_PATH}
                 className="govuk-header__link govuk-header__link--service-name"
               >
                 {AppConstants.APP_NAME}
-              </a>
-              {/* <button type="button" className="govuk-header__menu-button js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button> */}
+              </Link>
               <nav>
-                
                 <ul id="navigation" className="govuk-header__navigation " aria-label="Top Level Navigation">
+                  
                   {(this.state.navData).map(elem => {
                   const activeState = elem.active === true ? 'govuk-header__navigation-item govuk-header__navigation-item--active' : 'govuk-header__navigation-item';
                   return (
@@ -81,9 +101,23 @@ export class Header extends React.Component {
                     </li>
                   );
                 })}
-
                   <li className="govuk-header__navigation-item">
-                    <a className="govuk-header__link" onClick={this.logout}>Sign out</a>
+                    <Link 
+                      className="govuk-header__link" 
+                      to={AppConstants.SUPPORT_PATH}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      Support
+                    </Link>
+                  </li>
+                  <li className="govuk-header__navigation-item">
+                    <Link
+                      className="govuk-header__link" 
+                      onClick={this.logout}
+                    >
+                      Sign out
+                    </Link>
                   </li>
                 </ul>
 

--- a/app/core/components/Header.jsx
+++ b/app/core/components/Header.jsx
@@ -19,31 +19,37 @@ export class Header extends React.Component {
       this.state = {
         navData: [
           {
+            id: 'home',
             urlStem: AppConstants.DASHBOARD_PATH,
             text: 'Home',
             active: true,
           },
           {
+            id: 'tasks',
             urlStem: AppConstants.YOUR_TASKS_PATH,
             text: 'Tasks',
             active: false,
           },
           {
+            id: 'forms',
             urlStem: AppConstants.FORMS_PATH,
             text: 'Forms',
             active: false,
           },
           {
+            id: 'cases',
             urlStem: AppConstants.CASES_PATH,
             text: 'Cases',
             active: false,
           },
           {
+            id: 'reports',
             urlStem: AppConstants.REPORTS_PATH,
             text: 'Reports',
             active: false,
           },
           {
+            id: 'profile',
             urlStem: AppConstants.MY_PROFILE_PATH,
             text: 'My profile',
             active: false,
@@ -94,15 +100,16 @@ export class Header extends React.Component {
                 <ul id="navigation" className="govuk-header__navigation " aria-label="Top Level Navigation">
                   
                   {(this.state.navData).map(elem => {
-                  const activeState = elem.active === true ? 'govuk-header__navigation-item govuk-header__navigation-item--active' : 'govuk-header__navigation-item';
-                  return (
-                    <li className={activeState} key={elem.urlStem}>
-                      <Link to={elem.urlStem} className="govuk-header__link" onClick={() => this.setActivePage(elem.urlStem)}>{elem.text}</Link>
-                    </li>
-                  );
-                })}
+                    const activeState = elem.active === true ? 'govuk-header__navigation-item--active' : '';
+                    return (
+                      <li className={`govuk-header__navigation-item ${activeState}`} key={elem.urlStem}>
+                        <Link to={elem.urlStem} className="govuk-header__link" onClick={() => this.setActivePage(elem.urlStem)}>{elem.text}</Link>
+                      </li>
+                    );
+                  })}
                   <li className="govuk-header__navigation-item">
                     <Link 
+                      id='support'
                       className="govuk-header__link" 
                       to={AppConstants.SUPPORT_PATH}
                       target="_blank"
@@ -113,6 +120,7 @@ export class Header extends React.Component {
                   </li>
                   <li className="govuk-header__navigation-item">
                     <Link
+                      id='logout'
                       className="govuk-header__link" 
                       onClick={this.logout}
                     >

--- a/app/core/components/Header.scss
+++ b/app/core/components/Header.scss
@@ -1,0 +1,4 @@
+.govuk-header__content {
+  display: flex;
+  justify-content: space-between;
+}

--- a/app/core/components/Header.test.js
+++ b/app/core/components/Header.test.js
@@ -21,13 +21,6 @@ describe('Header', () => {
     expect(wrapper.exists()).toBe(true);
   });
 
-  it('renders Profile link', () => {
-    const wrapper = shallow(<Header {...props} />);
-    const node = wrapper.find('#profile');
-    expect(node.text()).toBe('My profile');
-    expect(node.prop('href')).toBe('/submit-a-form/edit-your-profile');
-  });
-
   it('matches snapshot', () => {
     const wrapper = shallow(<Header {...props} />);
     expect(wrapper).toMatchSnapshot();

--- a/app/core/components/__snapshots__/Header.test.js.snap
+++ b/app/core/components/__snapshots__/Header.test.js.snap
@@ -2,67 +2,127 @@
 
 exports[`Header matches snapshot 1`] = `
 <header
-  className="govuk-header"
+  className="govuk-header "
   data-module="header"
   role="banner"
 >
-  <SkipLink />
   <div
     className="govuk-header__container govuk-width-container"
   >
     <div
       className="govuk-header__content"
-      style={
-        Object {
-          "width": "100%",
-        }
-      }
     >
-      <div
-        className="govuk-grid-row"
+      <Link
+        className="govuk-header__link govuk-header__link--service-name"
+        id="serviceName"
+        to="/dashboard"
       >
-        <div
-          className="govuk-grid-column-one-half"
+        Central Operations Platform
+      </Link>
+      <nav>
+        <ul
+          aria-label="Top Level Navigation"
+          className="govuk-header__navigation "
+          id="navigation"
         >
-          <a
-            className="govuk-header__link govuk-header__link--service-name"
-            href="/dashboard"
-            id="dashboard"
-            onClick={[Function]}
+          <li
+            className="govuk-header__navigation-item govuk-header__navigation-item--active"
+            key="/dashboard"
           >
-            Central Operations Platform
-          </a>
-        </div>
-        <div
-          className="govuk-grid-column-one-half header-nav"
-        >
-          <a
-            className="govuk-header__link header-nav__link"
-            href="/submit-a-form/edit-your-profile"
-            id="profile"
-            onClick={[Function]}
+            <Link
+              className="govuk-header__link"
+              onClick={[Function]}
+              to="/dashboard"
+            >
+              Home
+            </Link>
+          </li>
+          <li
+            className="govuk-header__navigation-item "
+            key="/your-tasks"
           >
-            My profile
-          </a>
-          <a
-            className="govuk-header__link header-nav__link"
-            href="test"
-            id="support"
-            rel="noopener noreferrer"
-            target="_blank"
+            <Link
+              className="govuk-header__link"
+              onClick={[Function]}
+              to="/your-tasks"
+            >
+              Tasks
+            </Link>
+          </li>
+          <li
+            className="govuk-header__navigation-item "
+            key="/forms"
           >
-            Support
-          </a>
-          <a
-            className="govuk-header__link header-nav__link"
-            href="/logout"
-            id="logout"
-            onClick={[Function]}
+            <Link
+              className="govuk-header__link"
+              onClick={[Function]}
+              to="/forms"
+            >
+              Forms
+            </Link>
+          </li>
+          <li
+            className="govuk-header__navigation-item "
+            key="/cases"
           >
-            Sign out
-          </a>
-        </div>
-      </div>
+            <Link
+              className="govuk-header__link"
+              onClick={[Function]}
+              to="/cases"
+            >
+              Cases
+            </Link>
+          </li>
+          <li
+            className="govuk-header__navigation-item "
+            key="/reports"
+          >
+            <Link
+              className="govuk-header__link"
+              onClick={[Function]}
+              to="/reports"
+            >
+              Reports
+            </Link>
+          </li>
+          <li
+            className="govuk-header__navigation-item "
+            key="submit-a-form/edit-your-profile"
+          >
+            <Link
+              className="govuk-header__link"
+              onClick={[Function]}
+              to="submit-a-form/edit-your-profile"
+            >
+              My profile
+            </Link>
+          </li>
+          <li
+            className="govuk-header__navigation-item"
+          >
+            <Link
+              className="govuk-header__link"
+              id="support"
+              rel="noopener noreferrer"
+              target="_blank"
+              to="https://support.cop.homeoffice.gov.uk/servicedesk/customer/portal/3"
+            >
+              Support
+            </Link>
+          </li>
+          <li
+            className="govuk-header__navigation-item"
+          >
+            <Link
+              className="govuk-header__link"
+              id="logout"
+              onClick={[Function]}
+            >
+              Sign out
+            </Link>
+          </li>
+        </ul>
+      </nav>
     </div>
   </div>
 </header>


### PR DESCRIPTION
**AC**

- Additional navigation items added
- Active page highlighted in nav
- Note, mobile nav functionality will be added via different ticket as it does not exist today

**Testing**

- Navigation design should match that seen on https://cop.prototype.cop.homeoffice.gov.uk/blue/sprint-34/tasks-team-v0-0
- Navigation items should be in the order seen on the prototype above
- Navigation items should link to
- - Home: /dashboard
- - Tasks /your-tasks
- - Forms /forms
- - Cases /cases
- - Reports /reports
- - My profile /submit-a-form/edit-your-profile
- - Support https://support.cop.homeoffice.gov.uk/servicedesk/customer/portal/3 
- Support should open in a new tab
- Sign out should sign you out

