### PR TITLE
COP-1423 Mobile navigation updates

### DIFF
--- a/app/core/components/Header.jsx
+++ b/app/core/components/Header.jsx
@@ -18,12 +18,13 @@ export class Header extends React.Component {
       this.logout = this.logout.bind(this);
       this.dashboard = this.dashboard.bind(this);
       this.state = {
+        navMobileActive: false,
         navData: [
           {
             id: 'home',
             urlStem: AppConstants.DASHBOARD_PATH,
             text: 'Home',
-            active: true,
+            active: false,
           },
           {
             id: 'tasks',
@@ -78,6 +79,12 @@ export class Header extends React.Component {
       this.props.history.push(AppConstants.DASHBOARD_PATH);
   }
 
+  toggleNav(event) {
+    event.preventDefault();
+    const stateChange = this.state.navMobileActive = !this.state.navMobileActive
+    this.setState({ navMobileActive: stateChange })
+  }
+
   logout(event) {
       event.preventDefault();
       this.secureLocalStorage.removeAll();
@@ -86,7 +93,6 @@ export class Header extends React.Component {
 
   render() {
       return (
-
         <header className="govuk-header " role="banner" data-module="header">
           <SkipLink />
           <div className="govuk-header__container govuk-width-container">
@@ -98,9 +104,22 @@ export class Header extends React.Component {
               >
                 {AppConstants.APP_NAME}
               </Link>
+              <button 
+                type="button" 
+                className={this.state.navMobileActive === true ? 'govuk-header__menu-button govuk-js-header-toggle govuk-header__menu-button--open' : 'govuk-header__menu-button govuk-js-header-toggle'}
+                // className="govuk-header__menu-button govuk-js-header-toggle" 
+                aria-controls="navigation" 
+                aria-label="Show or hide Top Level Navigation"
+                onClick={event => this.toggleNav(event)}
+              >
+                Menu
+              </button>
               <nav>
-                <ul id="navigation" className="govuk-header__navigation " aria-label="Top Level Navigation">
-                  
+                <ul 
+                  id="navigation" 
+                  className={this.state.navMobileActive === true ? "govuk-header__navigation govuk-header__navigation--open" : "govuk-header__navigation"}
+                  aria-label="Top Level Navigation"
+                >
                   {(this.state.navData).map(elem => {
                     const activeState = elem.active === true ? 'govuk-header__navigation-item--active' : '';
                     return (
@@ -130,7 +149,6 @@ export class Header extends React.Component {
                     </Link>
                   </li>
                 </ul>
-
               </nav>
             </div>
           </div>

--- a/app/core/components/Header.jsx
+++ b/app/core/components/Header.jsx
@@ -17,7 +17,7 @@ export class Header extends React.Component {
       this.logout = this.logout.bind(this);
       this.dashboard = this.dashboard.bind(this);
       this.state = {
-        navMobileActive: false,
+        navMobileOpen: false,
         navData: [
           {
             id: 'home',
@@ -71,6 +71,7 @@ export class Header extends React.Component {
       }
     });
     this.setState({ navData: tempArr });
+    this.setState({ navMobileOpen: false })
   };
 
   dashboard(event) {
@@ -78,10 +79,10 @@ export class Header extends React.Component {
       this.props.history.push(AppConstants.DASHBOARD_PATH);
   }
 
-  toggleNavMobileActive(event) {
+  toggleNavMobileOpen(event) {
     event.preventDefault();
-    const stateChange = this.state.navMobileActive = !this.state.navMobileActive
-    this.setState({ navMobileActive: stateChange })
+    const stateChange = this.state.navMobileOpen = !this.state.navMobileOpen
+    this.setState({ navMobileOpen: stateChange })
   }
 
   logout(event) {
@@ -106,13 +107,13 @@ export class Header extends React.Component {
               <button 
                 type="button" 
                 className={
-                  this.state.navMobileActive === true 
+                  this.state.navMobileOpen === true 
                   ? 'govuk-header__menu-button govuk-js-header-toggle govuk-header__menu-button--open' 
                   : 'govuk-header__menu-button govuk-js-header-toggle'
                 }
                 aria-controls="navigation" 
                 aria-label="Show or hide Top Level Navigation"
-                onClick={event => this.toggleNavMobileActive(event)}
+                onClick={event => this.toggleNavMobileOpen(event)}
               >
                 Menu
               </button>
@@ -120,7 +121,7 @@ export class Header extends React.Component {
                 <ul 
                   id="navigation" 
                   className={
-                    this.state.navMobileActive === true 
+                    this.state.navMobileOpen === true 
                     ? "govuk-header__navigation govuk-header__navigation--open" 
                     : "govuk-header__navigation"
                   }

--- a/app/core/components/Header.jsx
+++ b/app/core/components/Header.jsx
@@ -8,7 +8,6 @@ import { withRouter, Link } from 'react-router-dom';
 import AppConstants from "../../common/AppConstants";
 import secureLocalStorage from '../../common/security/SecureLocalStorage';
 import SkipLink from './SkipLink';
-import './Header.scss';
 
 
 export class Header extends React.Component {
@@ -79,7 +78,7 @@ export class Header extends React.Component {
       this.props.history.push(AppConstants.DASHBOARD_PATH);
   }
 
-  toggleNav(event) {
+  toggleNavMobileActive(event) {
     event.preventDefault();
     const stateChange = this.state.navMobileActive = !this.state.navMobileActive
     this.setState({ navMobileActive: stateChange })
@@ -106,18 +105,25 @@ export class Header extends React.Component {
               </Link>
               <button 
                 type="button" 
-                className={this.state.navMobileActive === true ? 'govuk-header__menu-button govuk-js-header-toggle govuk-header__menu-button--open' : 'govuk-header__menu-button govuk-js-header-toggle'}
-                // className="govuk-header__menu-button govuk-js-header-toggle" 
+                className={
+                  this.state.navMobileActive === true 
+                  ? 'govuk-header__menu-button govuk-js-header-toggle govuk-header__menu-button--open' 
+                  : 'govuk-header__menu-button govuk-js-header-toggle'
+                }
                 aria-controls="navigation" 
                 aria-label="Show or hide Top Level Navigation"
-                onClick={event => this.toggleNav(event)}
+                onClick={event => this.toggleNavMobileActive(event)}
               >
                 Menu
               </button>
               <nav>
                 <ul 
                   id="navigation" 
-                  className={this.state.navMobileActive === true ? "govuk-header__navigation govuk-header__navigation--open" : "govuk-header__navigation"}
+                  className={
+                    this.state.navMobileActive === true 
+                    ? "govuk-header__navigation govuk-header__navigation--open" 
+                    : "govuk-header__navigation"
+                  }
                   aria-label="Top Level Navigation"
                 >
                   {(this.state.navData).map(elem => {

--- a/app/core/components/Header.jsx
+++ b/app/core/components/Header.jsx
@@ -15,7 +15,6 @@ export class Header extends React.Component {
       super(props);
       this.secureLocalStorage = secureLocalStorage;
       this.logout = this.logout.bind(this);
-      this.dashboard = this.dashboard.bind(this);
       this.state = {
         navMobileOpen: false,
         navData: [
@@ -59,25 +58,22 @@ export class Header extends React.Component {
       }
   }
 
-  setActivePage(url) {
+  handleLinkClick(url) {
+    // Set the nav link to it's active style
     const tempArr = [...this.state.navData];
     tempArr.map(elem => {
       const currentUrl = !url ? this.location.pathname : url;
       if (currentUrl === elem.urlStem) {
         elem.active = true;
-        document.activeElement.blur();
+        document.activeElement.blur(); // Remove the active element styling after click
       } else {
         elem.active = false;
       }
     });
     this.setState({ navData: tempArr });
+    // Ensure mobile menu is set to closed (false)
     this.setState({ navMobileOpen: false })
   };
-
-  dashboard(event) {
-      event.preventDefault();
-      this.props.history.push(AppConstants.DASHBOARD_PATH);
-  }
 
   toggleNavMobileOpen(event) {
     event.preventDefault();
@@ -131,7 +127,13 @@ export class Header extends React.Component {
                     const activeState = elem.active === true ? 'govuk-header__navigation-item--active' : '';
                     return (
                       <li className={`govuk-header__navigation-item ${activeState}`} key={elem.urlStem}>
-                        <Link to={elem.urlStem} className="govuk-header__link" onClick={() => this.setActivePage(elem.urlStem)}>{elem.text}</Link>
+                        <Link 
+                          to={elem.urlStem} 
+                          className="govuk-header__link" 
+                          onClick={() => this.handleLinkClick(elem.urlStem)}
+                        >
+                          {elem.text}
+                        </Link>
                       </li>
                     );
                   })}
@@ -147,13 +149,13 @@ export class Header extends React.Component {
                     </a>
                   </li>
                   <li className="govuk-header__navigation-item">
-                    <Link
+                    <a
                       id='logout'
                       className="govuk-header__link" 
                       onClick={this.logout}
                     >
                       Sign out
-                    </Link>
+                    </a>
                   </li>
                 </ul>
               </nav>

--- a/app/core/components/Header.scss
+++ b/app/core/components/Header.scss
@@ -1,5 +1,0 @@
-.govuk-header__content {
-  display: flex;
-  justify-content: space-between;
-  width: 100% !important;
-}

--- a/app/core/components/__snapshots__/Header.test.js.snap
+++ b/app/core/components/__snapshots__/Header.test.js.snap
@@ -20,14 +20,23 @@ exports[`Header matches snapshot 1`] = `
       >
         Central Operations Platform
       </Link>
+      <button
+        aria-controls="navigation"
+        aria-label="Show or hide Top Level Navigation"
+        className="govuk-header__menu-button govuk-js-header-toggle"
+        onClick={[Function]}
+        type="button"
+      >
+        Menu
+      </button>
       <nav>
         <ul
           aria-label="Top Level Navigation"
-          className="govuk-header__navigation "
+          className="govuk-header__navigation"
           id="navigation"
         >
           <li
-            className="govuk-header__navigation-item govuk-header__navigation-item--active"
+            className="govuk-header__navigation-item "
             key="/dashboard"
           >
             <Link
@@ -114,13 +123,13 @@ exports[`Header matches snapshot 1`] = `
           <li
             className="govuk-header__navigation-item"
           >
-            <Link
+            <a
               className="govuk-header__link"
               id="logout"
               onClick={[Function]}
             >
               Sign out
-            </Link>
+            </a>
           </li>
         </ul>
       </nav>

--- a/public/styles/app.scss
+++ b/public/styles/app.scss
@@ -85,8 +85,16 @@ input:disabled {
   margin-left: 20px;
 }
 
-.govuk-header__link--service-name {
-  margin-left: -15px;
+@media (min-width: 48.0625em) {
+  .govuk-header__link--service-name {
+    margin-left: -15px;
+  }
+
+  .govuk-header__content {
+    display: flex;
+    justify-content: space-between;
+    width: 100% !important;
+  }
 }
 
 


### PR DESCRIPTION
**AC**

- enable mobile nav show/hide nav links
- mobile links should be shown on the left below the service name
- onclick of link, menu should auto close
- service name should retain it's margins on mobile, even without GOV.UK logo

**Testing**

- open COP
- switch to a mobile width view
> you should see the 'menu' button rather than the nav links

- click on menu
- you should see the nav links on the left
- click on Tasks
> the menu should close & you should see your Tasks page

- switch to a desktop width view
> you should see the nav links once again