### PR TITLE
Update css to handle :link

### DIFF
--- a/app/pages/dashboard/components/CasesDashboardPanel.jsx
+++ b/app/pages/dashboard/components/CasesDashboardPanel.jsx
@@ -17,7 +17,7 @@ export class CasesDashboardPanel extends React.Component {
       <li className="govuk-grid-column-one-third" id="casesPanel">
         <a 
           href={AppConstants.CASES_PATH} 
-          className="govuk-heading-m govuk-link home-promo__link"
+          className="govuk-heading-m govuk-link"
           id="casesPageLink"
           onClick={e => this.cases(e)}
         >

--- a/app/pages/dashboard/components/FormsDashboardPanel.jsx
+++ b/app/pages/dashboard/components/FormsDashboardPanel.jsx
@@ -18,7 +18,7 @@ export class FormsDashboardPanel extends React.Component {
       <li className="govuk-grid-column-one-third" id="proceduresPanel">
         <a 
           href={AppConstants.FORMS_PATH}
-          className="govuk-heading-m govuk-link home-promo__link"
+          className="govuk-heading-m govuk-link"
           id="proceduresPageLink"
           onClick={e => this.procedures(e)}
         >

--- a/app/pages/dashboard/components/MessagesPanel.jsx
+++ b/app/pages/dashboard/components/MessagesPanel.jsx
@@ -71,7 +71,7 @@ export class MessagesPanel extends React.Component {
       <li className="govuk-grid-column-one-third" id="messagesPanel">
         <a
           href={AppConstants.MESSAGES_PATH}
-          className="govuk-heading-m govuk-link home-promo__link"
+          className="govuk-heading-m govuk-link"
           id="messagesPageLink"
           onClick={e => this.messages(e)}
         >

--- a/app/pages/dashboard/components/ReportsDashboardPanel.jsx
+++ b/app/pages/dashboard/components/ReportsDashboardPanel.jsx
@@ -17,7 +17,7 @@ export class ReportsDashboardPanel extends React.Component {
       <li className="govuk-grid-column-one-third" id="reportsPanel">
         <a 
           href={AppConstants.REPORTS_PATH}
-          className="govuk-heading-m govuk-link home-promo__link"
+          className="govuk-heading-m govuk-link"
           id="reportsPageLink"
           onClick={e => this.reports(e)}
         >

--- a/app/pages/dashboard/components/TaskCountPanel.jsx
+++ b/app/pages/dashboard/components/TaskCountPanel.jsx
@@ -85,7 +85,7 @@ export class TaskCountPanel extends React.Component {
         <li className="govuk-grid-column-one-third" id="yourTasksPanel">
           <a
             href={AppConstants.YOUR_TASKS_PATH}
-            className="govuk-heading-m govuk-link home-promo__link"
+            className="govuk-heading-m govuk-link"
             id="yourTasksPageLink"
             onClick={e => this.yourTasks(e)}
           >
@@ -101,7 +101,7 @@ export class TaskCountPanel extends React.Component {
         <li className="govuk-grid-column-one-third" id="youTeamTasks">
           <a
             href={AppConstants.YOUR_GROUP_TASKS_PATH}
-            className="govuk-heading-m govuk-link home-promo__link"
+            className="govuk-heading-m govuk-link"
             id="yourTeamTasksPageLink"
             onClick={e => this.yourTeamTotalTasks(e)}
           >

--- a/app/pages/dashboard/components/__snapshots__/FormsDashboardPanel.test.js.snap
+++ b/app/pages/dashboard/components/__snapshots__/FormsDashboardPanel.test.js.snap
@@ -18,7 +18,7 @@ exports[`Procedures Dashboard Panel renders forms dashboard panel 1`] = `
     id="proceduresPanel"
   >
     <a
-      className="govuk-heading-m govuk-link home-promo__link"
+      className="govuk-heading-m govuk-link"
       href="/forms"
       id="proceduresPageLink"
       onClick={[Function]}

--- a/app/pages/dashboard/components/__snapshots__/ReportsDashboardPanel.test.js.snap
+++ b/app/pages/dashboard/components/__snapshots__/ReportsDashboardPanel.test.js.snap
@@ -18,7 +18,7 @@ exports[`Reports Dashboard Panel renders reports dashboard panel 1`] = `
     id="reportsPanel"
   >
     <a
-      className="govuk-heading-m govuk-link home-promo__link"
+      className="govuk-heading-m govuk-link"
       href="/reports"
       id="reportsPageLink"
       onClick={[Function]}

--- a/public/styles/homeoffice.scss
+++ b/public/styles/homeoffice.scss
@@ -12,7 +12,7 @@
 
 // }
 
-.home-promo__link {
+.home-promo__link, .home-promo__link:link {
   color: #8F23B3;
 }
 .home-promo__link:visited {


### PR DESCRIPTION
GDS uses :link to style links, replicating that for our Home Office css to ensure it overwrites the GDS default