### PR TITLE
COP-1188 Case view search

### DIFF
--- a/app/core/Main.jsx
+++ b/app/core/Main.jsx
@@ -44,7 +44,7 @@ export const RouteWithTitle =({ title, ...props }) => {
 };
 
 const Main = () => (
-  <main className="govuk-main-wrapper govuk-!-padding-top-3" id="main-content" role="main">
+  <main className="govuk-main-wrapper" id="main-content" role="main">
     <Suspense fallback={<div style={{ justifyContent: 'center'}}><DataSpinner message="Loading routes" /></div>}>
       <Switch>
         <RouteWithTitle name="Accessibility Statement" title={`Accessibility Statement | ${AppConstants.APP_NAME}`} exact path="/accessibility-statement" component={AccessibilityStatement} />

--- a/app/core/components/Header.jsx
+++ b/app/core/components/Header.jsx
@@ -166,4 +166,3 @@ export default withRouter(connect(state => ({
 kc: state.keycloak,
 appConfig: state.appConfig,
 }), mapDispatchToProps)(Header));
-

--- a/app/core/components/Header.jsx
+++ b/app/core/components/Header.jsx
@@ -163,6 +163,7 @@ kc: PropTypes.shape({
 const mapDispatchToProps = dispatch => bindActionCreators({}, dispatch);
 
 export default withRouter(connect(state => ({
-kc: state.keycloak,
-appConfig: state.appConfig,
+  kc: state.keycloak,
+  appConfig: state.appConfig,
 }), mapDispatchToProps)(Header));
+

--- a/app/pages/cases/components/CaseResultsPanel.jsx
+++ b/app/pages/cases/components/CaseResultsPanel.jsx
@@ -5,10 +5,8 @@ import {bindActionCreators} from "redux";
 import PropTypes from "prop-types";
 import _ from "lodash";
 import {getCaseByKey} from '../actions';
-import {caseDetails, loadingCaseDetails, loadingNextSearchResults} from "../selectors";
+import {loadingNextSearchResults} from "../selectors";
 import withLog from "../../../core/error/component/withLog";
-import CaseDetailsPanel from "./CaseDetailsPanel";
-import DataSpinner from "../../../core/components/DataSpinner";
 
 class CaseResultsPanel extends React.Component {
 
@@ -21,7 +19,7 @@ class CaseResultsPanel extends React.Component {
   render() {
     const {
       searching, caseSearchResults,
-      businessKeyQuery, loadingCaseDetails, caseDetails,
+      businessKeyQuery,
       loadingNextSearchResults
     } = this.props;
 
@@ -84,16 +82,6 @@ class CaseResultsPanel extends React.Component {
             )} 
           </React.Fragment>
         )}
-        <div className="govuk-grid-column-three-quarters">
-          {loadingCaseDetails && (
-            <div style={{justifyContent: 'center', paddingTop: '20px'}}>
-              <DataSpinner
-                message="Loading case details"
-              />
-            </div>
-          )}
-          {/* {caseDetails && <CaseDetailsPanel {...{caseDetails}} />} */}
-        </div>
       </React.Fragment>
       )
     }
@@ -103,12 +91,7 @@ CaseResultsPanel.propTypes = {
     getCaseByKey: PropTypes.func.isRequired,
     loadNext: PropTypes.func,
     loadingNextSearchResults: PropTypes.bool,
-    loadingCaseDetails: PropTypes.bool,
     businessKey: PropTypes.string,
-    caseDetails: PropTypes.shape({
-        businessKey: PropTypes.string,
-        processInstances: PropTypes.arrayOf(PropTypes.object)
-    })
 };
 
 const mapDispatchToProps = dispatch => bindActionCreators({getCaseByKey}, dispatch);
@@ -117,8 +100,6 @@ export default withRouter(connect(state => {
     return {
         kc: state.keycloak,
         appConfig: state.appConfig,
-        caseDetails: caseDetails(state),
-        loadingCaseDetails: loadingCaseDetails(state),
         loadingNextSearchResults: loadingNextSearchResults(state)
 
     }

--- a/app/pages/cases/components/CaseResultsPanel.jsx
+++ b/app/pages/cases/components/CaseResultsPanel.jsx
@@ -12,93 +12,92 @@ import DataSpinner from "../../../core/components/DataSpinner";
 
 class CaseResultsPanel extends React.Component {
 
-    componentDidMount() {
-        if (this.props.businessKey) {
-            this.props.getCaseByKey(this.props.businessKey);
-        }
+  componentDidMount() {
+    if (this.props.businessKey) {
+      this.props.getCaseByKey(this.props.businessKey);
     }
+  }
 
-    render() {
-        const {
-            searching, caseSearchResults,
-            businessKeyQuery, loadingCaseDetails, caseDetails,
-            loadingNextSearchResults
-        } = this.props;
+  render() {
+    const {
+      searching, caseSearchResults,
+      businessKeyQuery, loadingCaseDetails, caseDetails,
+      loadingNextSearchResults
+    } = this.props;
 
-        if (searching) {
-            return <h4 className="govuk-heading-s">Searching cases with reference {businessKeyQuery}...</h4>
-        }
-        if (!caseSearchResults) {
-            return <div />
-        }
-        const hasMoreData = _.has(caseSearchResults._links, 'next');
+    if (searching) {
+      return <h4 className="govuk-heading-s">Searching cases with reference {businessKeyQuery}...</h4>
+    }
+    if (!caseSearchResults) {
+      return <div />
+    }
+    const hasMoreData = _.has(caseSearchResults._links, 'next');
 
-        if (!caseSearchResults._embedded) {
-            caseSearchResults._embedded = {
-                cases: []
-            }
-        }
-        const businessKeys = caseSearchResults._embedded.cases.map(c => {
-            return (
-              <li key={c.businessKey}><a
-                className="govuk-link"
-                href=""
-                onClick={event => {
-                event.preventDefault();
-                if (this.props.businessKey !== c.businessKey) {
-                    this.props.getCaseByKey(c.businessKey);
-                }
+    if (!caseSearchResults._embedded) {
+      caseSearchResults._embedded = {
+        cases: []
+      }
+    }
+    const businessKeys = caseSearchResults._embedded.cases.map(c => {
+      return (
+        <li key={c.businessKey}>
+          <a
+            className="govuk-link"
+            href=""
+            onClick={event => {
+              event.preventDefault();
+              if (this.props.businessKey !== c.businessKey) {
+                this.props.getCaseByKey(c.businessKey);
+              }
             }}
-              >{c.businessKey}
-              </a>
-              </li>
-)
-        });
-        return (
-          <div className="govuk-grid-row">
-            <div className="govuk-grid-column-one-quarter">
-              <h3 className="govuk-heading-m">Search results</h3>
-              {caseSearchResults ? (
-                <React.Fragment>
-                  <span className="govuk-caption-m">Number of cases found</span>
-                  <h3 className="govuk-heading-m">{caseSearchResults.page.totalElements}</h3>
+          >
+            {c.businessKey}
+          </a>
+        </li>
+      )
+    });
 
-                  {caseSearchResults.page.totalElements > 0 ? (
-                    <ul className="govuk-list">
-                      {businessKeys}
-                    </ul>
-) : null}
-                  {hasMoreData ? (
-                    <button
-                      className="govuk-button"
-                      disabled={loadingNextSearchResults}
-                      onClick={event => {
-                                        event.preventDefault();
-                                        this.props.loadNext();
-                                    }}
-                    >{loadingNextSearchResults ? 'Loading more' : 'Load more'}
-                    </button>
-                          ) : null}
-                </React.Fragment>
-                  ) : null}
+    return (
+      <React.Fragment>
+        {caseSearchResults && (
+          <React.Fragment>
+            <h3 className="govuk-heading-m">Search results</h3>
+            <p className="govuk-caption-m">Number of cases found</p>
+            <h3 className="govuk-heading-m">{caseSearchResults.page.totalElements}</h3>
+            {caseSearchResults.page.totalElements > 0 && (
+              <ul className="govuk-list">
+                {businessKeys}
+              </ul>
+            )}
+            {hasMoreData && (
+              <button
+                className="govuk-button"
+                type="submit"
+                disabled={loadingNextSearchResults}
+                onClick={event => {
+                  event.preventDefault();
+                  this.props.loadNext();
+                }}
+              >
+                {loadingNextSearchResults ? 'Loading more' : 'Load more'}
+              </button>
+            )} 
+          </React.Fragment>
+        )}
+        <div className="govuk-grid-column-three-quarters">
+          {loadingCaseDetails && (
+            <div style={{justifyContent: 'center', paddingTop: '20px'}}>
+              <DataSpinner
+                message="Loading case details"
+              />
             </div>
-            <div className="govuk-grid-column-three-quarters">
-              {
-                    loadingCaseDetails ? (
-                      <div style={{justifyContent: 'center', paddingTop: '20px'}}>
-                        <DataSpinner
-                          message="Loading case details"
-                        />
-                      </div>
-) :
-                        (!caseDetails ? null : <CaseDetailsPanel {...{caseDetails}} />)
-                }
-
-            </div>
-          </div>
-)
+          )}
+          {/* {caseDetails && <CaseDetailsPanel {...{caseDetails}} />} */}
+        </div>
+      </React.Fragment>
+      )
     }
-}
+  }
 
 CaseResultsPanel.propTypes = {
     getCaseByKey: PropTypes.func.isRequired,

--- a/app/pages/cases/components/CaseResultsPanel.jsx
+++ b/app/pages/cases/components/CaseResultsPanel.jsx
@@ -63,7 +63,7 @@ class CaseResultsPanel extends React.Component {
             <p className="govuk-caption-m">Number of cases found</p>
             <h3 className="govuk-heading-m">{caseSearchResults.page.totalElements}</h3>
             {caseSearchResults.page.totalElements > 0 && (
-              <ul className="govuk-list">
+              <ul className="govuk-list" id="searchResults">
                 {businessKeys}
               </ul>
             )}

--- a/app/pages/cases/components/CaseResultsPanel.test.jsx
+++ b/app/pages/cases/components/CaseResultsPanel.test.jsx
@@ -84,6 +84,8 @@ describe('CaseResultsPanel', () => {
           </Provider>
         </Router>);
 
-        expect(wrapper.html()).toEqual('<div class="govuk-grid-row"><div class="govuk-grid-column-one-quarter"><h3 class="govuk-heading-m">Search results</h3><span class="govuk-caption-m">Number of cases found</span><h3 class="govuk-heading-m">2</h3><ul class="govuk-list"><li><a class="govuk-link" href="">businessKey1</a></li><li><a class="govuk-link" href="">businessKey2</a></li></ul></div><div class="govuk-grid-column-three-quarters"></div></div>')
-    })
+        const resultsSection = wrapper.find('#searchResults');
+        expect(resultsSection.exists()).toBe(true);
+        expect(wrapper.html()).toEqual('<h3 class="govuk-heading-m">Search results</h3><p class="govuk-caption-m">Number of cases found</p><h3 class="govuk-heading-m">2</h3><ul class="govuk-list" id="searchResults"><li><a class="govuk-link" href="">businessKey1</a></li><li><a class="govuk-link" href="">businessKey2</a></li></ul>')
+    });
 });

--- a/app/pages/cases/components/CasesPage.jsx
+++ b/app/pages/cases/components/CasesPage.jsx
@@ -41,57 +41,73 @@ class CasesPage extends React.Component {
     return (
       <React.Fragment>
         <div className="govuk-grid-row">
-          <div className="govuk-grid-column-two-thirds">
-            <span className="govuk-caption-l">Case view</span>
-            <h2 className="govuk-heading-l">
-              Cases
-            </h2>
-            <div className="govuk-inset-text">
-              <p>Enter a COP number in quotes to search for cases—e.g. "COP-20200406-24".</p>
-              <p><strong>Please note all actions are audited.</strong></p>
-            </div>
+          <div className="govuk-grid-column-full">
+            <h1 className="govuk-heading-xl">Find a case</h1>
           </div>
-          <div className="govuk-grid-column-one-third">
-            <div className="govuk-form-group input-icon">
-              <DebounceInput
-                minLength={3}
-                debounceTimeout={1000}
-                spellCheck="false"
-                type="text"
-                className="govuk-input"
-                placeholder="Search using a COP prefixed number"
-                id="bfNumber"
-                onChange={event => {
+        </div>
+        <div className="govuk-grid-row">
+          <div className="govuk-grid-column-one-quarter">
+            <h3 className="govuk-heading-m">Case number search</h3>
+            <form>
+              <div className="govuk-form-group">
+                <label className="govuk-label" htmlFor="bfNumber">
+                  COP prefixed number
+                </label>
+                <span id="bfNumberHint" className="govuk-hint">
+                  Enter a COP number in quotes to search for cases e.g. "COP-20200406-24"
+                </span>
+                <DebounceInput
+                  minLength={3}
+                  debounceTimeout={1000}
+                  spellCheck="false"
+                  type="text"
+                  className="govuk-input"
+                  id="bfNumber"
+                  onChange={event => {
+                    const that = this;
+                    const query = event.target.value;
+                    window.history.pushState({}, null, '/cases');
+                    if (query === '') {
+                      that.props.resetCase();
+                    } else {
+                      that.props.findCasesByKey(query);
+                    }
+                  }}
+                />
+              </div>
+              <button 
+                className="govuk-button" 
+                type="submit"
+                onClick={event => {
+                  event.preventDefault();
                   const that = this;
                   const query = event.target.value;
                   window.history.pushState({}, null, '/cases');
-                  if (query === '') {
-                    that.props.resetCase();
-                  } else {
-                    that.props.findCasesByKey(query);
-                  }
+                  that.props.findCasesByKey(query);
                 }}
-              />
-              <i className="fa fa-search fa-lg" style={{ marginLeft: '5px' }} />
-            </div>
-          </div>
+              >
+                Search
+              </button>
+            </form>
+            <hr className="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
+            <CaseResultsPanel
+              {...{
+                businessKey,
+                caseSearchResults,
+                searching,
+                businessKeyQuery,
+                loadNext: () => {
+                  const links = caseSearchResults._links;
+                  if ('next' in links) {
+                    const that = this;
+                    const nextUrl = links.next.href;
+                    _.throttle(that.props.loadNextSearchResults(nextUrl), 300);
+                  }
+                },
+              }}
+            />
+          </div> 
         </div>
-        <CaseResultsPanel
-          {...{
-            businessKey,
-            caseSearchResults,
-            searching,
-            businessKeyQuery,
-            loadNext: () => {
-              const links = caseSearchResults._links;
-              if ('next' in links) {
-                const that = this;
-                const nextUrl = links.next.href;
-                _.throttle(that.props.loadNextSearchResults(nextUrl), 300);
-              }
-            },
-          }}
-        />
       </React.Fragment>
     );
   }

--- a/app/pages/cases/components/CasesPage.jsx
+++ b/app/pages/cases/components/CasesPage.jsx
@@ -20,6 +20,14 @@ import CaseDetailsPanel from "./CaseDetailsPanel";
 import DataSpinner from "../../../core/components/DataSpinner";
 
 class CasesPage extends React.Component {
+  constructor(props) {
+    super(props);
+    this.searchForCases = this.searchForCases.bind(this);
+    this.state = {
+      queryToSearch: ""
+    }
+  }
+
   componentDidMount() {
     const {
       match: { params },
@@ -33,6 +41,24 @@ class CasesPage extends React.Component {
   componentWillUnmount() {
     this.props.resetCase();
   }
+
+  setSearchQuery(event) {
+    const query = event.target.value;
+    this.setState({ queryToSearch: query });
+    this.searchForCases(event)
+  }
+  
+  searchForCases(event) {
+    event.preventDefault();
+    const that = this;
+    window.history.pushState({}, null, '/cases');
+    if (this.state.queryToSearch === '') {
+      that.props.resetCase();
+    } else {
+      that.props.findCasesByKey(this.state.queryToSearch);
+    }  
+  }
+
 
   render() {
     const {
@@ -69,28 +95,13 @@ class CasesPage extends React.Component {
                   type="text"
                   className="govuk-input"
                   id="bfNumber"
-                  onChange={event => {
-                    const that = this;
-                    const query = event.target.value;
-                    window.history.pushState({}, null, '/cases');
-                    if (query === '') {
-                      that.props.resetCase();
-                    } else {
-                      that.props.findCasesByKey(query);
-                    }
-                  }}
+                  onChange={event => this.setSearchQuery(event)}
                 />
               </div>
               <button 
                 className="govuk-button" 
                 type="submit"
-                onClick={event => {
-                  event.preventDefault();
-                  const that = this;
-                  const query = event.target.value;
-                  window.history.pushState({}, null, '/cases');
-                  that.props.findCasesByKey(query);
-                }}
+                onClick={event => this.searchForCases(event)}
               >
                 Search
               </button>

--- a/app/pages/cases/components/CasesPage.jsx
+++ b/app/pages/cases/components/CasesPage.jsx
@@ -13,7 +13,11 @@ import {
   caseSearchResults,
   loadingNextSearchResults,
   searching,
+  caseDetails,
+  loadingCaseDetails, 
 } from '../selectors';
+import CaseDetailsPanel from "./CaseDetailsPanel";
+import DataSpinner from "../../../core/components/DataSpinner";
 
 class CasesPage extends React.Component {
   componentDidMount() {
@@ -35,6 +39,8 @@ class CasesPage extends React.Component {
       caseSearchResults,
       searching,
       businessKeyQuery,
+      loadingCaseDetails, 
+      caseDetails,
       match: { params },
     } = this.props;
     const {businessKey} = params;
@@ -107,6 +113,16 @@ class CasesPage extends React.Component {
               }}
             />
           </div> 
+          <div className="govuk-grid-column-three-quarters">
+            {loadingCaseDetails && (
+              <div style={{justifyContent: 'center', paddingTop: '20px'}}>
+                <DataSpinner
+                  message="Loading case details"
+                />
+              </div>
+            )}
+            {caseDetails && <CaseDetailsPanel {...{caseDetails}} />}
+          </div>
         </div>
       </React.Fragment>
     );
@@ -138,6 +154,11 @@ CasesPage.propTypes = {
       number: PropTypes.number,
     }),
   }),
+  loadingCaseDetails: PropTypes.bool,
+  caseDetails: PropTypes.shape({
+    businessKey: PropTypes.string,
+    processInstances: PropTypes.arrayOf(PropTypes.object)
+  })
 };
 
 const mapDispatchToProps = dispatch =>
@@ -155,6 +176,8 @@ export default withRouter(
       caseSearchResults: caseSearchResults(state),
       searching: searching(state),
       loadingNextSearchResults: loadingNextSearchResults(state),
+      caseDetails: caseDetails(state),
+      loadingCaseDetails: loadingCaseDetails(state),
     }),
     mapDispatchToProps,
   )(withLog(CasesPage)),

--- a/app/pages/cases/components/CasesPage.jsx
+++ b/app/pages/cases/components/CasesPage.jsx
@@ -125,6 +125,13 @@ class CasesPage extends React.Component {
             />
           </div> 
           <div className="govuk-grid-column-three-quarters">
+            {(!loadingCaseDetails && !caseDetails) && (
+              <div>
+                <p class="govuk-body-l">To view the details of a specific case within COP please enter the COP reference number to the left.</p>
+                <p class="govuk-body">For a more detailed search query please use the reporting section within COP or an alternative product such as the Single Intelligence Platform (SIP) or the Criminal Intelligence Database (CID).</p>
+                <p class="govuk-body">Please note that all queries are audited.</p>
+              </div>
+            )}
             {loadingCaseDetails && (
               <div style={{justifyContent: 'center', paddingTop: '20px'}}>
                 <DataSpinner


### PR DESCRIPTION
**AC**

Based on https://cop.prototype.cop.homeoffice.gov.uk/blue/sprint-34/case-overview?nginxId=a9c445dc-30d4-4df8-cd75-68b9fb259576

- setup 1/4 + 3/4 page structure
- add search panel
- add search result panel
- add search button functionality

----

**To test**

- go to /cases page
- enter a known businessKey
> you should see the search result list
- click on the link for the businessKey
> you should see the case (with it's current design) on the right panel

- try to enter a search query and click the search button before the automatic search kicks in
> you should see the search result list


