### PR TITLE
COP-1407 Update default sort order for tasks to be by oldest due date

### DIFF
--- a/app/pages/tasks/components/SortTasks.jsx
+++ b/app/pages/tasks/components/SortTasks.jsx
@@ -15,10 +15,10 @@ const SortTasks = ({sortValue, sortTasks}) => {
         style={types.isMobile?  {width: '100%'} : null}
         value={sortValue}
       >
-        <option value="sort=due,desc">Latest due date</option>
         <option value="sort=due,asc">Oldest due date</option>
-        <option value="sort=created,desc">Latest created date</option>
+        <option value="sort=due,desc">Latest due date</option>
         <option value="sort=created,asc">Oldest created date</option>
+        <option value="sort=created,desc">Latest created date</option>
         <option value="sort=priority,desc">Highest priority</option>
         <option value="sort=priority,asc">Lowest priority</option>
       </select>

--- a/app/pages/tasks/components/YourGroupTasks.test.jsx
+++ b/app/pages/tasks/components/YourGroupTasks.test.jsx
@@ -19,7 +19,7 @@ describe('YourGroupTasksContainer Page', () => {
   const yourGroupTasks = {
     history,
     isFetchingTasks: false,
-    sortValue: 'sort=due,desc',
+    sortValue: 'sort=due,asc',
     total: 1,
     tasks: Immutable.fromJS([
       {
@@ -183,11 +183,11 @@ describe('YourGroupTasksContainer Page', () => {
 
     filterInput.simulate('change', { target: { value: 'ABC' } });
     jest.advanceTimersByTime(600);
-    expect(fetchYourGroupTasks).toBeCalledWith('sort=due,desc', 'ABC', true);
+    expect(fetchYourGroupTasks).toBeCalledWith('sort=due,asc', 'ABC', true);
 
     filterInput.simulate('change', { target: { value: 'APPLES' } });
     jest.advanceTimersByTime(600);
-    expect(fetchYourGroupTasks).toBeCalledWith('sort=due,desc', 'APPLES', true);
+    expect(fetchYourGroupTasks).toBeCalledWith('sort=due,asc', 'APPLES', true);
   });
 
   it('executes timer', async () => {
@@ -201,7 +201,7 @@ describe('YourGroupTasksContainer Page', () => {
         },
       },
       isFetchingTasks: false,
-      sortValue: 'sort=due,desc',
+      sortValue: 'sort=due,asc',
       filterValue: 'TEST',
       total: 1,
       tasks: Immutable.fromJS([
@@ -228,11 +228,11 @@ describe('YourGroupTasksContainer Page', () => {
       </Provider>,
     );
 
-    expect(fetchYourGroupTasks).toBeCalledWith('sort=due,desc', null, false);
+    expect(fetchYourGroupTasks).toBeCalledWith('sort=due,asc', null, false);
 
     // kick off timer
     jest.advanceTimersByTime(AppConstants.REFRESH_TIMEOUT);
-    expect(fetchYourGroupTasks).toBeCalledWith('sort=due,desc', 'TEST', true);
+    expect(fetchYourGroupTasks).toBeCalledWith('sort=due,asc', 'TEST', true);
 
     //
     wrapper.unmount();
@@ -251,7 +251,7 @@ describe('YourGroupTasksContainer Page', () => {
       history,
       claimSuccessful: true,
       isFetchingTasks: false,
-      sortValue: 'sort=due,desc',
+      sortValue: 'sort=due,asc',
       filterValue: 'TEST',
       total: 1,
       tasks: Immutable.fromJS([

--- a/app/pages/tasks/components/YourGroupTasksContainer.jsx
+++ b/app/pages/tasks/components/YourGroupTasksContainer.jsx
@@ -41,7 +41,7 @@ export class YourGroupTasksContainer extends React.Component {
   }
 
   componentDidMount() {
-    this.loadYourGroupTasks(false, 'sort=due,desc');
+    this.loadYourGroupTasks(false, 'sort=due,asc');
     const that = this;
     const {groupYourTeamTasks} = this.props;
     this.timeoutId = setInterval(() => {
@@ -187,7 +187,7 @@ YourGroupTasksContainer.defaultProps = {
   claimSuccessful: false,
   tasks: new List([]),
   total: 0,
-  sortValue: 'sort=due,desc',
+  sortValue: 'sort=due,asc',
   filterValue: null,
   groupBy: 'category'
 };

--- a/app/pages/tasks/components/YourTasks.test.jsx
+++ b/app/pages/tasks/components/YourTasks.test.jsx
@@ -17,7 +17,7 @@ describe('YourTasks Page', () => {
   const date = moment();
   const yourTasks = {
     isFetchingTasks: false,
-    sortValue: 'sort=due,desc',
+    sortValue: 'sort=due,asc',
     appConfig: {
       uiEnvironment: 'local',
     },
@@ -284,7 +284,7 @@ describe('YourTasks Page', () => {
     yourTaskFilterInput.simulate('change', { target: { value: 'ABC' } });
     jest.advanceTimersByTime(600);
     expect(fetchTasksAssignedToYou).toBeCalledWith(
-      'sort=due,desc',
+      'sort=due,asc',
       'ABC',
       true,
     );
@@ -292,7 +292,7 @@ describe('YourTasks Page', () => {
     yourTaskFilterInput.simulate('change', { target: { value: 'APPLES' } });
     jest.advanceTimersByTime(600);
     expect(fetchTasksAssignedToYou).toBeCalledWith(
-      'sort=due,desc',
+      'sort=due,asc',
       'APPLES',
       true,
     );
@@ -314,7 +314,7 @@ describe('YourTasks Page', () => {
       groupYourTasks: jest.fn(),
       history,
       isFetchingTasks: false,
-      sortValue: 'sort=due,desc',
+      sortValue: 'sort=due,asc',
       filterValue: 'TEST',
       resetYourTasks: jest.fn(),
       total: 1,

--- a/app/pages/tasks/components/YourTasksContainer.jsx
+++ b/app/pages/tasks/components/YourTasksContainer.jsx
@@ -40,7 +40,7 @@ export class YourTasksContainer extends React.Component {
     }
 
     componentDidMount() {
-        this.loadYourTasks(false, 'sort=due,desc');
+        this.loadYourTasks(false, 'sort=due,asc');
         if (secureLocalStorage.get('yourTasksGrouping')) {
             const {groupYourTasks} = this.props;
             groupYourTasks(secureLocalStorage.get('yourTasksGrouping'));
@@ -180,7 +180,7 @@ YourTasksContainer.defaultProps = {
     isFetchingTasks: true,
     tasks: new List([]),
     total: 0,
-    sortValue: 'sort=due,desc',
+    sortValue: 'sort=due,asc',
     filterValue: null,
     groupBy: 'category'
 };

--- a/app/pages/tasks/epic.js
+++ b/app/pages/tasks/epic.js
@@ -8,7 +8,7 @@ const fetchTasksAssignedYou = (action$, store, { client }) => action$.ofType(typ
   .mergeMap(action => client({
     method: 'GET',
     path: `${store.getState().appConfig.workflowServiceUrl}/api/workflow/tasks?assignedToMeOnly=true&${action.sortValue
-      ? action.sortValue : 'sort=due,desc'}${action.filterValue ? `&name=${action.filterValue}` : ''}`,
+      ? action.sortValue : 'sort=due,asc'}${action.filterValue ? `&name=${action.filterValue}` : ''}`,
     headers: {
       Accept: 'application/json',
       Authorization: `Bearer ${store.getState().keycloak.token}`,
@@ -21,7 +21,7 @@ const fetchYourGroupTasks = (action$, store, { client }) => action$.ofType(types
   .mergeMap(action => client({
     method: 'GET',
     path: `${store.getState().appConfig.workflowServiceUrl}/api/workflow/tasks?teamOnly=true&${action.sortValue
-      ? action.sortValue : 'sort=due,desc'}${action.filterValue ? `&name=${action.filterValue}` : ''}`,
+      ? action.sortValue : 'sort=due,asc'}${action.filterValue ? `&name=${action.filterValue}` : ''}`,
     headers: {
       Accept: 'application/json',
       Authorization: `Bearer ${store.getState().keycloak.token}`,

--- a/app/pages/tasks/reducer.js
+++ b/app/pages/tasks/reducer.js
@@ -7,7 +7,7 @@ export const initialState = new Map({
     isFetchingTasks: false,
     tasks: new List([]),
     total: 0,
-    sortValue: 'sort=due,desc',
+    sortValue: 'sort=due,asc',
     filterValue: null,
     groupBy: 'category',
     nextPageUrl: null,

--- a/app/pages/tasks/reducer.test.js
+++ b/app/pages/tasks/reducer.test.js
@@ -5,13 +5,13 @@ import * as actions from './actions';
 
 describe('Tasks reducer', () => {
   it('fetches tasks assigned to you', () => {
-    const expected = reducer(initialState, actions.fetchTasksAssignedToYou('sort=due,desc', 'ABC', false));
+    const expected = reducer(initialState, actions.fetchTasksAssignedToYou('sort=due,asc', 'ABC', false));
     expect(expected.get('isFetchingTasks'))
       .toEqual(true);
     expect(expected.get('filterValue'))
       .toEqual('ABC');
     expect(expected.get('sortValue'))
-      .toEqual('sort=due,desc');
+      .toEqual('sort=due,asc');
   });
   it('successfully fetches tasks', () => {
     const expected = reducer(initialState, actions.fetchTasksAssignedToYouSuccess({
@@ -47,7 +47,7 @@ describe('Tasks reducer', () => {
     expect(expected.get('filterValue'))
         .toBeNull();
     expect(expected.get('sortValue'))
-        .toEqual('sort=due,desc');
+        .toEqual('sort=due,asc');
   });
   it('returns isFetchingTasks false if failed', () => {
     const expected = reducer(initialState, actions.fetchTasksAssignedToYouFailure());
@@ -78,7 +78,7 @@ describe('Tasks reducer', () => {
         },
       ]),
       total: 0,
-      sortValue: 'sort=due,desc',
+      sortValue: 'sort=due,asc',
       filterValue: null,
     });
 


### PR DESCRIPTION
**AC**

The default sort order for lists of tasks should be by oldest due date (`sort=due,asc`)

**TO TEST**

- login to COP
- go to Team Tasks
> you should see the sort dropdown as `Oldest due date`
> you should see the 'overdue' column indicating the oldest due tasks are first e.g. `Overdue 12 hours ago` should be above `Overdue 2 hours ago`

- Change the sort dropdown to `Latest due date`
> you should see the order change and now `Overdue 2 hours ago` should be above `Overdue 12 hours ago`

- go to Your Tasks
> you should see the sort dropdown as `Oldest due date`
> you should see the 'overdue' column indicating the oldest due tasks are first e.g. `Overdue 12 hours ago` should be above `Overdue 2 hours ago`

- Change the sort dropdown to `Latest due date`
> you should see the order change and now `Overdue 2 hours ago` should be above `Overdue 12 hours ago`