### PR TITLE
Request mobile layout of Power BI reports when suitable

### DIFF
--- a/app/common/AppConstants.js
+++ b/app/common/AppConstants.js
@@ -32,4 +32,6 @@ export default class AppConstants {
     static CASES_PATH = "/cases";
 
     static REFRESH_TIMEOUT = 300000;
+
+    static MOBILE_WIDTH = 640;
 }

--- a/app/common/AppConstants.js
+++ b/app/common/AppConstants.js
@@ -1,35 +1,35 @@
 export default class AppConstants {
   static APP_NAME = 'Central Operations Platform';
 
+  static CALENDAR_PATH = '/calendar';
+
+  static CASES_PATH = '/cases';
+
   static DASHBOARD_PATH = '/dashboard';
-
-  static YOUR_TASKS_PATH = '/your-tasks';
-
-  static YOUR_GROUP_TASKS_PATH = '/your-group-tasks';
 
   static FORMS_PATH = '/forms';
 
-  static REPORTS_PATH = '/reports';
+  static MESSAGES_PATH = '/messages';
+
+  static MOBILE_WIDTH = 640;
+
+  static ONBOARD_USER_PATH = '/onboard-user';
+
+  static PROCEDURE_DIAGRAM_PATH = '/procedure-diagram';
+
+  static REFRESH_TIMEOUT = 300000;
 
   static REPORT_PATH = '/report';
 
-  static MESSAGES_PATH = '/messages';
+  static REPORTS_PATH = '/reports';
 
-  static CALENDAR_PATH = '/calendar';
+  static SHIFT_PATH = '/shift';
 
   static SUBMIT_A_FORM = '/submit-a-form';
 
   static TASK_PATH = '/task';
 
-  static SHIFT_PATH = '/shift';
+  static YOUR_GROUP_TASKS_PATH = '/your-group-tasks';
 
-  static PROCEDURE_DIAGRAM_PATH = '/procedure-diagram';
-
-  static ONBOARD_USER_PATH = '/onboard-user';
-
-  static CASES_PATH = '/cases';
-
-  static REFRESH_TIMEOUT = 300000;
-
-  static MOBILE_WIDTH = 640;
+  static YOUR_TASKS_PATH = '/your-tasks';
 }

--- a/app/common/AppConstants.js
+++ b/app/common/AppConstants.js
@@ -1,37 +1,35 @@
-
 export default class AppConstants {
+  static APP_NAME = 'Central Operations Platform';
 
-    static APP_NAME = 'Central Operations Platform';
+  static DASHBOARD_PATH = '/dashboard';
 
-    static DASHBOARD_PATH = '/dashboard';
+  static YOUR_TASKS_PATH = '/your-tasks';
 
-    static YOUR_TASKS_PATH = '/your-tasks';
+  static YOUR_GROUP_TASKS_PATH = '/your-group-tasks';
 
-    static YOUR_GROUP_TASKS_PATH = '/your-group-tasks';
+  static FORMS_PATH = '/forms';
 
-    static FORMS_PATH = '/forms';
+  static REPORTS_PATH = '/reports';
 
-    static REPORTS_PATH = '/reports';
+  static REPORT_PATH = '/report';
 
-    static REPORT_PATH = '/report';
+  static MESSAGES_PATH = '/messages';
 
-    static MESSAGES_PATH = '/messages';
+  static CALENDAR_PATH = '/calendar';
 
-    static CALENDAR_PATH = '/calendar';
+  static SUBMIT_A_FORM = '/submit-a-form';
 
-    static SUBMIT_A_FORM = '/submit-a-form';
+  static TASK_PATH = '/task';
 
-    static TASK_PATH='/task';
+  static SHIFT_PATH = '/shift';
 
-    static SHIFT_PATH = '/shift';
+  static PROCEDURE_DIAGRAM_PATH = '/procedure-diagram';
 
-    static PROCEDURE_DIAGRAM_PATH = '/procedure-diagram';
+  static ONBOARD_USER_PATH = '/onboard-user';
 
-    static ONBOARD_USER_PATH='/onboard-user';
+  static CASES_PATH = '/cases';
 
-    static CASES_PATH = "/cases";
+  static REFRESH_TIMEOUT = 300000;
 
-    static REFRESH_TIMEOUT = 300000;
-
-    static MOBILE_WIDTH = 640;
+  static MOBILE_WIDTH = 640;
 }

--- a/app/pages/reports/components/PowerBIReport.jsx
+++ b/app/pages/reports/components/PowerBIReport.jsx
@@ -1,4 +1,5 @@
 import React, { Component, Fragment } from 'react';
+import { models } from 'powerbi-client';
 import PropTypes from 'prop-types';
 import Report from 'powerbi-report-component';
 import LogoBar from '../../../core/components/LogoBar';
@@ -19,7 +20,16 @@ export default class PowerBIReport extends Component {
   };
 
   render() {
-    const { accessToken, embedUrl, id: embedId, name: pageName } = this.props;
+    const {
+      accessToken,
+      embedUrl,
+      id: embedId,
+      name: pageName,
+      useMobileLayout,
+    } = this.props;
+    const logoBar = useMobileLayout ? null : (
+      <LogoBar setFullscreen={this.setFullscreen} />
+    );
     return (
       <Fragment>
         <Report
@@ -27,6 +37,9 @@ export default class PowerBIReport extends Component {
           embedType="report"
           extraSettings={{
             filterPaneEnabled: false,
+            layoutType: useMobileLayout
+              ? models.LayoutType.MobilePortrait
+              : models.LayoutType.Master,
           }}
           onLoad={this.handleReportLoad}
           permissions="Read"
@@ -34,7 +47,7 @@ export default class PowerBIReport extends Component {
           style={{ width: '100%', height: '100%' }}
           tokenType="Embed"
         />
-        <LogoBar setFullscreen={this.setFullscreen} />
+        {logoBar}
       </Fragment>
     );
   }
@@ -45,4 +58,5 @@ PowerBIReport.propTypes = {
   embedUrl: PropTypes.string.isRequired,
   id: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
+  useMobileLayout: PropTypes.bool.isRequired,
 };

--- a/app/pages/reports/components/PowerBIReport.test.jsx
+++ b/app/pages/reports/components/PowerBIReport.test.jsx
@@ -7,11 +7,24 @@ describe('PowerBIReport', () => {
     embedUrl: 'http://www.example.com',
     id: 'abc',
     name: 'Power BI Report',
+    useMobileLayout: true,
   };
 
   it('renders a PowerBIReport', () => {
     const wrapper = shallow(<PowerBIReport {...props} />);
     expect(wrapper.find('Report').exists()).toEqual(true);
+  });
+
+  it('does not render a LogoBar if narrow screen', () => {
+    const wrapper = shallow(<PowerBIReport {...props} />);
+    expect(wrapper.find('LogoBar').exists()).toEqual(false);
+  });
+
+  it('renders a LogoBar if wide screen', () => {
+    const wrapper = shallow(
+      <PowerBIReport {...{ ...props, useMobileLayout: false }} />,
+    );
+    expect(wrapper.find('LogoBar').exists()).toEqual(true);
   });
 
   it('matches snapshot', () => {

--- a/app/pages/reports/components/ReportPage.jsx
+++ b/app/pages/reports/components/ReportPage.jsx
@@ -18,7 +18,7 @@ export const ReportPage = ({ appConfig, location }) => {
     name,
     reportType,
   } = location.state;
-  const useMobileLayout = window.innerWidth < 500;
+  const useMobileLayout = window.innerWidth < AppConstants.MOBILE_WIDTH;
   document.title = `${name} | ${AppConstants.APP_NAME}`;
 
   return (

--- a/app/pages/reports/components/ReportPage.jsx
+++ b/app/pages/reports/components/ReportPage.jsx
@@ -18,6 +18,7 @@ export const ReportPage = ({ appConfig, location }) => {
     name,
     reportType,
   } = location.state;
+  const useMobileLayout = window.innerWidth < 500;
   document.title = `${name} | ${AppConstants.APP_NAME}`;
 
   return (
@@ -32,14 +33,16 @@ export const ReportPage = ({ appConfig, location }) => {
 
       <div
         style={{
-          height: '50vw',
+          height: useMobileLayout ? '50vh' : '50vw',
           margin: 'auto',
-          maxHeight: '70vmin',
+          maxHeight: useMobileLayout ? null : '70vmin',
           position: 'relative',
         }}
       >
         {reportType === 'PowerBIReport' ? (
-          <PowerBIReport {...{ accessToken, embedUrl, id, name }} />
+          <PowerBIReport
+            {...{ accessToken, embedUrl, id, name, useMobileLayout }}
+          />
         ) : (
           <HTMLReport {...{ htmlName, reportServiceUrl }} />
         )}

--- a/app/pages/reports/components/__snapshots__/PowerBIReport.test.jsx.snap
+++ b/app/pages/reports/components/__snapshots__/PowerBIReport.test.jsx.snap
@@ -10,6 +10,7 @@ exports[`PowerBIReport matches snapshot 1`] = `
     extraSettings={
       Object {
         "filterPaneEnabled": false,
+        "layoutType": 2,
       }
     }
     onLoad={[Function]}
@@ -23,9 +24,6 @@ exports[`PowerBIReport matches snapshot 1`] = `
       }
     }
     tokenType="Embed"
-  />
-  <LogoBar
-    setFullscreen={[Function]}
   />
 </Fragment>
 `;

--- a/package-lock.json
+++ b/package-lock.json
@@ -13007,20 +13007,20 @@
       "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
     },
     "powerbi-client": {
-      "version": "2.11.0",
-      "resolved": "http://localhost:4873/powerbi-client/-/powerbi-client-2.11.0.tgz",
-      "integrity": "sha512-IvCn/VIoOg87e3SVGGgWIN1Igi+WW8byiEepAY/0FvUJ2uG7Y0bOgpfSLxwIgTWEHIMfIAZpx4NYzpiPMZibrA==",
+      "version": "2.13.3",
+      "resolved": "http://localhost:4873/powerbi-client/-/powerbi-client-2.13.3.tgz",
+      "integrity": "sha512-gS5/fWv5oBzpSkpXC/2ubdhn0vCQa3CK+SUr/DRdBQBPWKvXdonjzcNu2zUjyTcqP61yhTNBLU4hKRgE/dMM2w==",
       "requires": {
         "http-post-message": "^0.2",
-        "powerbi-models": "^1.3",
+        "powerbi-models": "^1.4",
         "powerbi-router": "^0.1",
         "window-post-message-proxy": "^0.2"
       }
     },
     "powerbi-models": {
-      "version": "1.3.4",
-      "resolved": "http://localhost:4873/powerbi-models/-/powerbi-models-1.3.4.tgz",
-      "integrity": "sha512-hphw7boqjh/GSTUg4xZNoUE5/SWGTKWZhDZHapl1lIsbq2uXQQWVr6k9uyvZDLfTakE4+o18SBcIQe4IRNAduQ=="
+      "version": "1.4.0",
+      "resolved": "http://localhost:4873/powerbi-models/-/powerbi-models-1.4.0.tgz",
+      "integrity": "sha512-SNdY3SSjOU1DHs3mgyvi2jv1UvTIXoxrbdZBEjsePQ7bo6Rp425Q6qKCE7kHgJz5fjOZ6tPU5+zT+J4J7xYFQQ=="
     },
     "powerbi-report-component": {
       "version": "1.8.5",

--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
     "lodash": "^4.17.19",
     "moment": "^2.22.0",
     "piwik-react-router": "^0.12.1",
+    "powerbi-client": "^2.13.3",
     "powerbi-report-component": "^1.4.2",
     "prop-types": "^15.6.2",
     "pubsub-js": "^1.6.0",


### PR DESCRIPTION
For any window width lower than 500px we instead request the mobile report layout, if available, and change the iframe height. If one is not available, the main ("Master") one will load. This looks good in testing for me, but will ask Jade to check, too.