### PR TITLE
COP-1407 Assign priorities and group

### DIFF
--- a/app/common/AppConstants.js
+++ b/app/common/AppConstants.js
@@ -1,6 +1,8 @@
 export default class AppConstants {
+  // Names
   static APP_NAME = 'Central Operations Platform';
 
+  // App paths
   static CALENDAR_PATH = '/calendar';
 
   static CASES_PATH = '/cases';
@@ -11,13 +13,9 @@ export default class AppConstants {
 
   static MESSAGES_PATH = '/messages';
 
-  static MOBILE_WIDTH = 640;
-
   static ONBOARD_USER_PATH = '/onboard-user';
 
   static PROCEDURE_DIAGRAM_PATH = '/procedure-diagram';
-
-  static REFRESH_TIMEOUT = 300000;
 
   static REPORT_PATH = '/report';
 
@@ -32,4 +30,24 @@ export default class AppConstants {
   static YOUR_GROUP_TASKS_PATH = '/your-group-tasks';
 
   static YOUR_TASKS_PATH = '/your-tasks';
+
+  // Priorities
+  static HIGH_PRIORITY_LABEL = 'High';
+
+  static HIGH_PRIORITY_LOWER_LIMIT = 150;
+
+  static LOW_PRIORITY_LABEL = 'Low';
+
+  static LOW_PRIORITY_UPPER_LIMIT = 50;
+
+  static MEDIUM_PRIORITY_LABEL = 'Medium';
+
+  static MEDIUM_PRIORITY_LOWER_LIMIT = 100;
+
+  // Sizes
+  static MOBILE_WIDTH = 640;
+
+  // Timers
+  static REFRESH_TIMEOUT = 300000;
+
 }

--- a/app/common/AppConstants.js
+++ b/app/common/AppConstants.js
@@ -32,17 +32,20 @@ export default class AppConstants {
   static YOUR_TASKS_PATH = '/your-tasks';
 
   // Priorities
-  static HIGH_PRIORITY_LABEL = 'High';
-
+  // -- LOWER_LIMIT states the lowest priority number a task can have for it to be classified as medium or high
+  // -- UPPER_LIMIT states the highest priority number a task can have for it to be classified as low
+  // -- These are used both for creating bandings in priority.js and for setting the value of the select fields where a user can switch a priority
   static HIGH_PRIORITY_LOWER_LIMIT = 150;
 
-  static LOW_PRIORITY_LABEL = 'Low';
+  static MEDIUM_PRIORITY_LOWER_LIMIT = 100;
 
   static LOW_PRIORITY_UPPER_LIMIT = 50;
 
+  static HIGH_PRIORITY_LABEL = 'High';
+
   static MEDIUM_PRIORITY_LABEL = 'Medium';
 
-  static MEDIUM_PRIORITY_LOWER_LIMIT = 100;
+  static LOW_PRIORITY_LABEL = 'Low';
 
   // Sizes
   static MOBILE_WIDTH = 640;

--- a/app/core/util/priority.js
+++ b/app/core/util/priority.js
@@ -1,14 +1,18 @@
+/* eslint-disable import/prefer-default-export */
+import AppConstants from '../../common/AppConstants';
+
 export const priority = priority => {
+  const high = AppConstants.HIGH_PRIORITY_LABEL;
+  const medium = AppConstants.MEDIUM_PRIORITY_LABEL;
+  const low = AppConstants.LOW_PRIORITY_LABEL;
+  const valueHigh = AppConstants.HIGH_PRIORITY_LOWER_LIMIT;
+  const valueLow = AppConstants.LOW_PRIORITY_UPPER_LIMIT;
   let result = null;
-  switch (priority) {
-    case 50:
-      result = 'Low';
-      break;
-    case 100:
-      result = 'Medium';
-      break;
-    default:
-      result = 'High';
-  }
+
+  if (priority <= valueLow) { result = low }
+  else if (priority > valueLow && priority < valueHigh) { result = medium }
+  else if (priority >= valueHigh) { result = high }
+  else { result = medium }
+
   return result;
 };

--- a/app/pages/task/display/component/TaskTitle.jsx
+++ b/app/pages/task/display/component/TaskTitle.jsx
@@ -4,6 +4,7 @@ import React, { useState } from 'react';
 import moment from 'moment';
 import {Link} from "react-router-dom";
 import { priority } from '../../../../core/util/priority';
+import AppConstants from '../../../../common/AppConstants';
 
 const TaskTitle = props => {
   const { kc, task, businessKey, processDefinition, updateTask, isUpdatingTask, history} = props;
@@ -185,9 +186,9 @@ const TaskTitle = props => {
                   onChange={e => setTPriority(e.target.value)}
                   defaultValue={task.get('priority')}
                 >
-                  <option value="1000">High</option>
-                  <option value="100">Medium</option>
-                  <option value="50">Low</option>
+                  <option value={AppConstants.HIGH_PRIORITY_LOWER_LIMIT}>{AppConstants.HIGH_PRIORITY_LABEL}</option>
+                  <option value={AppConstants.MEDIUM_PRIORITY_LOWER_LIMIT}>{AppConstants.MEDIUM_PRIORITY_LABEL}</option>
+                  <option value={AppConstants.LOW_PRIORITY_UPPER_LIMIT}>{AppConstants.LOW_PRIORITY_LABEL}</option>
                 </select>
               </div>
               <div>

--- a/app/pages/tasks/components/TaskUtils.js
+++ b/app/pages/tasks/components/TaskUtils.js
@@ -1,82 +1,81 @@
 import _ from "lodash";
 import moment from "moment";
+import AppConstants from "../../../common/AppConstants";
 import {priority} from "../../../core/util/priority";
 
 export default class TaskUtils {
 
-    buildPaginationAction(props) {
-        const pagination = {};
-        // eslint-disable-next-line no-shadow
-        const {nextPageUrl, prevPageUrl, firstPageUrl, lastPageUrl, load} = props;
-        if (firstPageUrl) {
-            pagination.onFirst = () => {
-                load(`${firstPageUrl}&${props.sortValue}${props.filterValue? `&name=${props.filterValue}`: ''}`);
-            };
-        }
-        if (prevPageUrl) {
-            pagination.onPrev = () => {
-                load(`${prevPageUrl}&${props.sortValue}${props.filterValue? `&name=${props.filterValue}`: ''}`);
-            };
-        }
-        if (nextPageUrl) {
-            pagination.onNext = () => {
-                load(`${nextPageUrl}&${props.sortValue}${props.filterValue? `&name=${props.filterValue}`: ''}`);
-            };
-        }
-        if (lastPageUrl) {
-            pagination.onLast = () => {
-                load(`${lastPageUrl}&${props.sortValue}${props.filterValue? `&name=${props.filterValue}`: ''}`);
-            };
-        }
-        return pagination;
+  buildPaginationAction(props) {
+    const pagination = {};
+    const {nextPageUrl, prevPageUrl, firstPageUrl, lastPageUrl, load} = props;
+    if (firstPageUrl) {
+      pagination.onFirst = () => {
+        load(`${firstPageUrl}&${props.sortValue}${props.filterValue? `&name=${props.filterValue}`: ''}`);
+      };
+    }
+    if (prevPageUrl) {
+      pagination.onPrev = () => {
+        load(`${prevPageUrl}&${props.sortValue}${props.filterValue? `&name=${props.filterValue}`: ''}`);
+      };
+    }
+    if (nextPageUrl) {
+      pagination.onNext = () => {
+        load(`${nextPageUrl}&${props.sortValue}${props.filterValue? `&name=${props.filterValue}`: ''}`);
+      };
+    }
+    if (lastPageUrl) {
+      pagination.onLast = () => {
+        load(`${lastPageUrl}&${props.sortValue}${props.filterValue? `&name=${props.filterValue}`: ''}`);
+      };
+    }
+    return pagination;
     }
 
-    applyGrouping(groupBy, tasks) {
-        switch (groupBy) {
-            case 'reference':
-                const byReference = _.groupBy(tasks, data => {
-                    return data.businessKey;
-                });
-                const sortKeys = _.orderBy(Object.keys(byReference), o => {
-                    return moment(o.split('-')[1]).format('YYYYMMDD');
-                }, ['desc']);
+  applyGrouping(groupBy, tasks) {
+    switch (groupBy) {
+      case 'reference':
+        const byReference = _.groupBy(tasks, data => {
+          return data.businessKey;
+        });
+        const sortKeys = _.orderBy(Object.keys(byReference), o => {
+          return moment(o.split('-')[1]).format('YYYYMMDD');
+        }, ['desc']);
+        return _.fromPairs(_.map(sortKeys, key => [key, byReference[key]]));
 
-                return _.fromPairs(_.map(sortKeys, key => [key, byReference[key]]));
-            case 'priority':
-                const byPriority = _.groupBy(tasks, data => {
-                    return data.task.priority;
-                });
-                const sortByPriority = _.orderBy(Object.keys(byPriority), key => {
-                    return Number(key);
-                }, ['desc']);
-                return _.fromPairs(_.map(sortByPriority, key => {
-                    return [priority(Number(` ${  key}`)).trim(), byPriority[key]]
-                }));
-            default:
-                const sortByKeys = object => {
-                    const sort = _.orderBy(Object.keys(object), [key => key.toLowerCase()], ['asc']);
-                    return _.fromPairs(_.map(sort, key => [key, object[key]]));
-                };
-                return sortByKeys(_.groupBy(tasks, data => {
-                    return data['process-definition'] ? data['process-definition'].category : 'Other';
-                }));
-        }
+      case 'priority':
+        const byPriority = _.groupBy(tasks, key => {
+          return priority(Number(` ${key.task.priority}`)).trim()
+        });
+        const sortByPriority = [AppConstants.HIGH_PRIORITY_LABEL, AppConstants.MEDIUM_PRIORITY_LABEL, AppConstants.LOW_PRIORITY_LABEL];
+        return _.fromPairs(_.map(sortByPriority, key => {
+          const groupedTasks = byPriority[key] ? [key, byPriority[key]] : [key, 0];
+          return groupedTasks;
+        }));
+
+      default:
+        const sortByKeys = object => {
+          const sort = _.orderBy(Object.keys(object), [key => key.toLowerCase()], ['asc']);
+          return _.fromPairs(_.map(sort, key => [key, object[key]]));
+        };
+      return sortByKeys(_.groupBy(tasks, data => {
+        return data['process-definition'] ? data['process-definition'].category : 'Other';
+      }));
     }
+  }
 
-    generateCaption(grouping, val) {
-        let caption;
-        switch (grouping) {
-            case 'category':
-            case 'priority':
-                caption = val.businessKey;
-                break;
-            case 'reference':
-                caption = val['process-definition'].category;
-                break;
-            default:
-                caption = '';
-
-        }
-        return caption;
-    };
+  generateCaption(grouping, val) {
+    let caption;
+    switch (grouping) {
+      case 'category':
+      case 'priority':
+        caption = val.businessKey;
+        break;
+      case 'reference':
+        caption = val['process-definition'].category;
+        break;
+      default:
+        caption = '';
+    }
+    return caption;
+  };
 }

--- a/app/pages/tasks/components/TaskUtils.test.js
+++ b/app/pages/tasks/components/TaskUtils.test.js
@@ -1,52 +1,125 @@
-import Immutable from 'immutable';
 import TaskUtils from "./TaskUtils";
-
-
-const {Map} = Immutable;
 
 describe('TaskUtils', () => {
     const taskUtils = new TaskUtils();
-    const data = [{
-        'businessKey': 'DEV-20200210-1223',
+    const data = [
+      {
+        'businessKey': 'DEV-20200120-1221',
         'process-definition': {
-            'category': 'B'
+          'category': 'B'
         },
         task: {
-            name: 'test1',
-            priority: 50
+          name: 'test1',
+          priority: 100 // test what we expect to be  Medium: 100
         }
-    },
-        {
-            'process-definition': {
-                'category': 'a'
-            },
-            'businessKey': 'DEV-20200220-1223',
-            task: {
-                name: 'test2',
-                priority: 1000
-            }
-        }];
-    it('groups by reference', () => {
-        const result = taskUtils.applyGrouping('reference', data);
-        const keys = Object.keys(result);
-        expect(keys[0]).toEqual('DEV-20200220-1223');
-        expect(keys[1]).toEqual('DEV-20200210-1223');
+      },
+      {
+        'process-definition': {
+          'category': 'a'
+        },
+        'businessKey': 'DEV-20200220-1222', // test group by key can group more than one item
+        task: {
+          name: 'test2',
+          priority: 1000 // test in case something is set to 1000, it returns High
+        }
+      },
+      {
+        'process-definition': {
+          'category': 'a'
+        },
+        'businessKey': 'DEV-20200420-1224', 
+        task: {
+          name: 'test2'
+          // test if there is no priority set it defaults to Medium
+        }
+      },
+      {
+        'process-definition': {
+          'category': 'a'
+        },
+        'businessKey': 'DEV-20200420-1224',
+        task: {
+          name: 'test2',
+          priority: null // test if priority is null it defaults to Medium
+        }
+      },
+      {
+        'process-definition': {
+          'category': 'a'
+        },
+        'businessKey': 'DEV-20200420-1224',
+        task: {
+          name: 'test2',
+          priority: 'seven' // test if priority is NaN it defaults to Medium
+        }
+      }, 
+      {
+        'process-definition': {
+          'category': 'a'
+        },
+        'businessKey': 'DEV-20200220-1222', // test group by key can group more than one item
+        task: {
+          name: 'test4',
+          priority: 150 // test what we expect to be as High: 150
+        }
+      },
+      {
+        'process-definition': {
+          'category': 'a'
+        },
+        'businessKey': 'DEV-20200320-1223',
+        task: {
+          name: 'test3',
+          priority: 250 // test in case something is set to 250, it returns High
+      }
+    }];
 
+    it('returns the expected references', () => {
+      const result = taskUtils.applyGrouping('reference', data);
+      const keys = Object.keys(result);
+      expect(keys).toContainEqual('DEV-20200120-1221');
+      expect(keys).toContainEqual('DEV-20200220-1222');
+      expect(keys).toContainEqual('DEV-20200320-1223');
+      expect(keys).toContainEqual('DEV-20200420-1224');
+    });
+
+    it('groups by reference', () => {
+      const result = taskUtils.applyGrouping('reference', data);
+      expect(result["DEV-20200220-1222"]).toHaveLength(2);
+      expect(result["DEV-20200320-1223"]).toHaveLength(1);
+      expect(result["DEV-20200120-1221"]).toHaveLength(1);
+      expect(result["DEV-20200420-1224"]).toHaveLength(3);
+    })
+
+    it('orders priority groups correctly', () => {
+      const result = taskUtils.applyGrouping('priority', data);
+      const keys = Object.keys(result);
+      expect(keys[0]).toEqual('High');
+      expect(keys[1]).toEqual('Medium');
+      expect(keys[2]).toEqual('Low');
     });
 
     it('groups by priority', () => {
-        const result = taskUtils.applyGrouping('priority', data);
-        const keys = Object.keys(result);
-        expect(keys[0]).toEqual('High');
-        expect(keys[1]).toEqual('Low');
+      const result = taskUtils.applyGrouping('priority', data);
+      expect(result.High).toHaveLength(3);
+      expect(result.Medium).toHaveLength(4);
+    })
 
+  it('sets value to 0 if there are 0 tasks for a priority', () => {
+    const result = taskUtils.applyGrouping('priority', data);
+    expect(result.Low).toBe(0);
+  })
+
+    it('returns the expected categories', () => {
+      const result = taskUtils.applyGrouping('category', data);
+      const keys = Object.keys(result);
+      expect(keys).toContainEqual('a');
+      expect(keys).toContainEqual('B');
     });
 
-    it('groups by category', () => {
-
-        const result = taskUtils.applyGrouping('category', data);
-        const keys = Object.keys(result);
-        expect(keys[0]).toEqual('a');
-        expect(keys[1]).toEqual('B');
-    });
+  it('groups by categories', () => {
+    const result = taskUtils.applyGrouping('category', data);
+    expect(result.a).toHaveLength(6);
+    expect(result.B).toHaveLength(1);
+  })
 })

--- a/app/pages/tasks/components/YourGroupTasks.jsx
+++ b/app/pages/tasks/components/YourGroupTasks.jsx
@@ -28,14 +28,25 @@ const YourGroupTasks = props => {
     paginationActions
   } = props;
 
+
   const dataToDisplay = _.map(yourGroupTasks, (value, key) => {
     const tasks = value.length === 1 ? 'task' : 'tasks';
     return (
       <div id="taskGroups" key={key} className="govuk-grid-row">
         <div className="govuk-grid-column-full">
-          <h3 className="govuk-heading-m">
-            {key} ({value.length} {tasks})
-          </h3>
+          {value.length > 0 && (
+            <React.Fragment>
+              <hr
+                style={{
+                borderBottom: '3px solid #1d70b8',
+                borderTop: 'none',
+              }}
+              />
+              <h3 className="govuk-heading-m">
+                {`${key} ${value.length} ${tasks}`}
+              </h3>
+            </React.Fragment>
+          )}
           {_.map(value, val => {
             const { task } = val;
             const due = moment(task.due);
@@ -124,12 +135,6 @@ const YourGroupTasks = props => {
               </div>
             );
           })}
-          <hr
-            style={{
-              borderBottom: '3px solid #1d70b8',
-              borderTop: 'none',
-            }}
-          />
         </div>
       </div>
     );


### PR DESCRIPTION
**AC**
There is a bug that prevents some tasks from showing when you group by Priority in tasklist

**Updated**
 * assignment of High, Medium, Low based on bandings
 * change default priority when no priority value is available to {{Medium}}

**Notes**
 * BPMN's will be updated to use 50/100/150
 * It's confirmed the guide documents use 50/100/150
 * Anything to do with changes to BPMNs is not addressed in this PR
 * Tasks without a specific priority set in the user task element of the BPMN are being created with a priority value of 50. This will be investigated in https://support.cop.homeoffice.gov.uk/browse/COP-256

**To test**
 * Create an Events at the Border task
 * Create an Intel Referral task and choose `Time constraint: yes`
 * Create an Intel Referral task and choose `Time constraint: no`
 * Open your group task list
 * Sort by `Latest created`
 * Group by `Priority`

>You should see your EaB set in High
>You should see your Enhance, time constraint yes, set in Medium
>You should see your Enhance, time constraint no, set in Low


The above tests the specific change made.