### PR TITLE
COP-1803 Persist sort order

### DIFF
--- a/app/common/security/SecureLocalStorage.js
+++ b/app/common/security/SecureLocalStorage.js
@@ -9,7 +9,7 @@ const secureLocalStorage = new SecureLS({
 export const clearAllExceptDefault = () => {
     secureLocalStorage
         .getAllKeys()
-        .filter(key => !['shift', 'extendedStaffDetails', 'yourTasksGrouping', 'yourTeamTasksGrouping'].includes(key))
+        .filter(key => !['shift', 'extendedStaffDetails', 'yourTasksGrouping', 'yourTeamTasksGrouping', 'yourTasksSorting', 'yourTeamTasksSorting', ].includes(key))
         .forEach(key => secureLocalStorage.remove(key));
 };
 

--- a/app/common/security/SecureLocalStorage.js
+++ b/app/common/security/SecureLocalStorage.js
@@ -1,16 +1,23 @@
 import SecureLS from 'secure-ls';
 
 const secureLocalStorage = new SecureLS({
-    encodingType: 'aes',
-    encryptionSecret: process.env.WWW_STORAGE_KEY,
-    isCompression: true,
+  encodingType: 'aes',
+  encryptionSecret: process.env.WWW_STORAGE_KEY,
+  isCompression: true,
 });
 
 export const clearAllExceptDefault = () => {
-    secureLocalStorage
-        .getAllKeys()
-        .filter(key => !['shift', 'extendedStaffDetails', 'yourTasksGrouping', 'yourTeamTasksGrouping', 'yourTasksSorting', 'yourTeamTasksSorting', ].includes(key))
-        .forEach(key => secureLocalStorage.remove(key));
+  secureLocalStorage
+    .getAllKeys()
+    .filter(key => ![
+      'shift', 
+      'extendedStaffDetails', 
+      'yourTasksGrouping', 
+      'yourTeamTasksGrouping', 
+      'yourTasksSorting', 
+      'yourTeamTasksSorting', 
+    ].includes(key))
+    .forEach(key => secureLocalStorage.remove(key));
 };
 
 export default secureLocalStorage;

--- a/app/pages/tasks/components/SortTasks.jsx
+++ b/app/pages/tasks/components/SortTasks.jsx
@@ -5,7 +5,6 @@ import PropTypes from 'prop-types';
 const SortTasks = ({sortValue, sortTasks}) => {
   return (
     <div className="govuk-form-group">
-      {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
       <label className="govuk-label" htmlFor="sortTask">Sort tasks by:</label>
       <select
         className="govuk-select"
@@ -26,8 +25,8 @@ const SortTasks = ({sortValue, sortTasks}) => {
 )};
 
 SortTasks.propTypes = {
-    sortValue: PropTypes.string.isRequired,
-    sortTasks: PropTypes.func.isRequired
+  sortValue: PropTypes.string.isRequired,
+  sortTasks: PropTypes.func.isRequired
 };
 
 export default SortTasks;

--- a/app/pages/tasks/components/YourGroupTasksContainer.jsx
+++ b/app/pages/tasks/components/YourGroupTasksContainer.jsx
@@ -41,10 +41,10 @@ export class YourGroupTasksContainer extends React.Component {
 
   componentDidMount() {
     if (secureLocalStorage.get('yourTeamTasksSorting')) {
-          this.loadYourGroupTasks(false, secureLocalStorage.get('yourTeamTasksSorting'));
-        } else {
-          this.loadYourGroupTasks(false, 'sort=due,asc');
-        }
+      this.loadYourGroupTasks(false, secureLocalStorage.get('yourTeamTasksSorting'));
+    } else {
+      this.loadYourGroupTasks(false, 'sort=due,asc');
+    }
     const that = this;
     const {groupYourTeamTasks} = this.props;
     this.timeoutId = setInterval(() => {
@@ -195,8 +195,6 @@ YourGroupTasksContainer.defaultProps = {
   filterValue: null,
   groupBy: 'category'
 };
-
-
 
 YourGroupTasksContainer.propTypes = {
   kc: PropTypes.shape({

--- a/app/pages/tasks/components/YourGroupTasksContainer.jsx
+++ b/app/pages/tasks/components/YourGroupTasksContainer.jsx
@@ -122,6 +122,7 @@ export class YourGroupTasksContainer extends React.Component {
   }
 
   sortYourGroupTasks(event) {
+    secureLocalStorage.set('yourTeamTasksSorting', event.target.value);
     const {fetchYourGroupTasks, filterValue:filter} = this.props;
     fetchYourGroupTasks(
       event.target.value,

--- a/app/pages/tasks/components/YourGroupTasksContainer.jsx
+++ b/app/pages/tasks/components/YourGroupTasksContainer.jsx
@@ -40,7 +40,11 @@ export class YourGroupTasksContainer extends React.Component {
   }
 
   componentDidMount() {
-    this.loadYourGroupTasks(false, 'sort=due,asc');
+    if (secureLocalStorage.get('yourTeamTasksSorting')) {
+          this.loadYourGroupTasks(false, secureLocalStorage.get('yourTeamTasksSorting'));
+        } else {
+          this.loadYourGroupTasks(false, 'sort=due,asc');
+        }
     const that = this;
     const {groupYourTeamTasks} = this.props;
     this.timeoutId = setInterval(() => {

--- a/app/pages/tasks/components/YourTasksContainer.jsx
+++ b/app/pages/tasks/components/YourTasksContainer.jsx
@@ -2,13 +2,11 @@ import ImmutablePropTypes from 'react-immutable-proptypes';
 import PropTypes from 'prop-types';
 import React from 'react';
 import SockJS from 'sockjs-client';
-
 import {Client} from '@stomp/stompjs';
 import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
 import {debounce, throttle} from 'throttle-debounce';
 import {withRouter} from 'react-router';
-
 import {List} from "immutable";
 import * as actions from '../actions';
 import DataSpinner from '../../../core/components/DataSpinner';
@@ -28,201 +26,189 @@ import TaskUtils from "./TaskUtils";
 
 
 export class YourTasksContainer extends React.Component {
-    constructor(props) {
-        super(props);
-        this.websocketSubscriptions = [];
-        this.connect = this.connect.bind(this);
-        this.goToTask = this.goToTask.bind(this);
-        this.sortYourTasks = this.sortYourTasks.bind(this);
-        this.filterTasksByName = this.filterTasksByName.bind(this);
-        this.debounceSearch = this.debounceSearch.bind(this);
+  constructor(props) {
+    super(props);
+    this.websocketSubscriptions = [];
+    this.connect = this.connect.bind(this);
+    this.goToTask = this.goToTask.bind(this);
+    this.sortYourTasks = this.sortYourTasks.bind(this);
+    this.filterTasksByName = this.filterTasksByName.bind(this);
+    this.debounceSearch = this.debounceSearch.bind(this);
+  }
+
+  componentDidMount() {
+    if (secureLocalStorage.get('yourTasksSorting')) {
+      this.loadYourTasks(false, secureLocalStorage.get('yourTasksSorting'));
+    } else {
+      this.loadYourTasks(false, 'sort=due,asc');
     }
-
-    componentDidMount() {
-
-        if (secureLocalStorage.get('yourTasksSorting')) {
-          this.loadYourTasks(false, secureLocalStorage.get('yourTasksSorting'));
-        } else {
-          this.loadYourTasks(false, 'sort=due,asc');
-        }
-        if (secureLocalStorage.get('yourTasksGrouping')) {
-            const {groupYourTasks} = this.props;
-            groupYourTasks(secureLocalStorage.get('yourTasksGrouping'));
-        }
+    if (secureLocalStorage.get('yourTasksGrouping')) {
+      const {groupYourTasks} = this.props;
+      groupYourTasks(secureLocalStorage.get('yourTasksGrouping'));
     }
+  }
 
-
-    componentWillUnmount() {
-        const { resetYourTasks } = this.props;
-        if (this.client) {
-            this.client.deactivate();
-        }
-        resetYourTasks();
+  componentWillUnmount() {
+    const { resetYourTasks } = this.props;
+    if (this.client) {
+      this.client.deactivate();
     }
+    resetYourTasks();
+  }
 
-    connect = user => {
-        const {appConfig} = this.props;
-        const uiEnv = appConfig.uiEnvironment.toLowerCase();
-        this.client = new Client({
-            debug (str) {
-                if (uiEnv === 'development' || uiEnv === 'local') {
-                    console.log(str);
-                }
-            },
-            reconnectDelay: 5000,
-            heartbeatIncoming: 4000,
-            heartbeatOutgoing: 4000
-        });
+  connect = user => {
+    const {appConfig} = this.props;
+    const uiEnv = appConfig.uiEnvironment.toLowerCase();
+    this.client = new Client({
+      debug (str) {
+        if (uiEnv === 'development' || uiEnv === 'local') {
+          console.log(str);
+        }
+      },
+      reconnectDelay: 5000,
+      heartbeatIncoming: 4000,
+      heartbeatOutgoing: 4000
+    });
 
-        const self = this;
-        this.client.webSocketFactory = function () {
-            return new SockJS(`${self.props.appConfig.workflowServiceUrl}/ws/workflow/tasks?access_token=${self.props.kc.token}`);
-        };
-        this.client.onConnect = function () {
-            // eslint-disable-next-line no-unused-vars
-            const {log, loadYourTasks, websocketSubscriptions, sortValue, filterValue} = self;
-            log([{
-                message: 'Connected to websocket',
-                user,
-                level: 'info',
-                path: self.props.location.pathname
-            }]);
-            const userSub = self.client.subscribe('/user/queue/task', () => {
-                loadYourTasks(true, sortValue,
-                    filterValue);
-            });
-            self.websocketSubscriptions.push(userSub);
-            log([{
-                message: `Number of subscriptions ${self.websocketSubscriptions.length}`,
-                user,
-                level: 'info',
-                path: self.props.location.pathname
-            }]);
-        };
-
-        this.client.onStompError = function (frame) {
-            self.props.log([{
-                message: `Failed to connect ${frame.headers.message}`,
-                user,
-                level: 'error',
-                path: self.props.location.pathname
-            }]);
-        };
-        this.client.activate();
+    const self = this;
+    this.client.webSocketFactory = function () {
+      return new SockJS(`${self.props.appConfig.workflowServiceUrl}/ws/workflow/tasks?access_token=${self.props.kc.token}`);
     };
+    this.client.onConnect = function () {
+    // eslint-disable-next-line no-unused-vars
+    const {log, loadYourTasks, websocketSubscriptions, sortValue, filterValue} = self;
+    log([{
+      message: 'Connected to websocket',
+      user,
+      level: 'info',
+      path: self.props.location.pathname
+    }]);
+    const userSub = self.client.subscribe('/user/queue/task', () => {
+      loadYourTasks(true, sortValue,
+      filterValue);
+    });
+    self.websocketSubscriptions.push(userSub);
+    log([{
+      message: `Number of subscriptions ${self.websocketSubscriptions.length}`,
+      user,
+      level: 'info',
+      path: self.props.location.pathname
+    }]);
+  };
 
+  this.client.onStompError = function (frame) {
+    self.props.log([{
+      message: `Failed to connect ${frame.headers.message}`,
+      user,
+      level: 'error',
+      path: self.props.location.pathname
+    }]);
+  };
+    this.client.activate();
+  };
 
+  loadYourTasks(skipLoading, yourTasksSortValue, yourTasksFilterValue = null) {
+    const { fetchTasksAssignedToYou } = this.props;
+    fetchTasksAssignedToYou(yourTasksSortValue, yourTasksFilterValue, skipLoading);
+  }
 
-    loadYourTasks(skipLoading, yourTasksSortValue, yourTasksFilterValue = null) {
-        const { fetchTasksAssignedToYou } = this.props;
-        fetchTasksAssignedToYou(yourTasksSortValue, yourTasksFilterValue, skipLoading);
+  goToTask(taskId) {
+    const { history } = this.props;
+    history.replace(`/task/${taskId}?from=yourTasks`);
+  }
+
+  debounceSearch(sort, filter) {
+    const {fetchTasksAssignedToYou} = this.props;
+    if (filter.length <= 2 || filter.endsWith(' ')) {
+      throttle(200, () => {
+        fetchTasksAssignedToYou(sort, filter, true);
+      })();
+    } else {
+      debounce(500, () => {
+        fetchTasksAssignedToYou(sort, filter, true);
+      })();
     }
+  }
 
-    goToTask(taskId) {
-        const { history } = this.props;
-        history.replace(`/task/${taskId}?from=yourTasks`);
+  filterTasksByName(event) {
+    event.persist();
+    const {sortValue:sort} = this.props;
+    this.debounceSearch(sort, event.target.value);
+  }
+
+  sortYourTasks(event) {
+    secureLocalStorage.set('yourTasksSorting', event.target.value);
+    const {fetchTasksAssignedToYou, filterValue:filter} = this.props;
+    fetchTasksAssignedToYou(event.target.value, filter, true);
+  }
+
+
+  render() {
+    const {isFetchingTasks, groupBy, tasks, total, sortValue, filterValue, groupYourTasks} = this.props;
+
+    if (isFetchingTasks) {
+      return <DataSpinner message="Fetching tasks assigned to you" />;
     }
-
-
-
-    debounceSearch(sort, filter) {
-        const {fetchTasksAssignedToYou} = this.props;
-        if (filter.length <= 2 || filter.endsWith(' ')) {
-            throttle(200, () => {
-                fetchTasksAssignedToYou(sort, filter, true);
-            })();
-        } else {
-            debounce(500, () => {
-                fetchTasksAssignedToYou(sort, filter, true);
-            })();
-        }
-    }
-
-    filterTasksByName(event) {
-        event.persist();
-        const {sortValue:sort} = this.props;
-        this.debounceSearch(sort, event.target.value);
-    }
-
-    sortYourTasks(event) {
-        secureLocalStorage.set('yourTasksSorting', event.target.value);
-        const {fetchTasksAssignedToYou, filterValue:filter} = this.props;
-        fetchTasksAssignedToYou(event.target.value, filter, true);
-    }
-
-
-
-    render() {
-
-        const {isFetchingTasks, groupBy, tasks, total, sortValue, filterValue, groupYourTasks} = this.props;
-
-        if (isFetchingTasks) {
-            return <DataSpinner message="Fetching tasks assigned to you" />;
-        }
-        return (
-          <YourTasks
-            grouping={groupBy}
-            paginationActions={
-               TaskUtils.buildPaginationAction(this.props)
-            }
-            filterTasksByName={this.filterTasksByName}
-            sortYourTasks={this.sortYourTasks}
-            goToTask={this.goToTask}
-            yourTasks={TaskUtils.applyGrouping(groupBy, tasks.toJS())}
-            total={total}
-            sortValue={sortValue}
-            filterValue={filterValue}
-            groupTasks={grouping => {
-                    secureLocalStorage.set('yourTasksGrouping', grouping);
-                    groupYourTasks(grouping)
-                }}
-          />
-        );
-    }
+    return (
+      <YourTasks
+        grouping={groupBy}
+        paginationActions={TaskUtils.buildPaginationAction(this.props)}
+        filterTasksByName={this.filterTasksByName}
+        sortYourTasks={this.sortYourTasks}
+        goToTask={this.goToTask}
+        yourTasks={TaskUtils.applyGrouping(groupBy, tasks.toJS())}
+        total={total}
+        sortValue={sortValue}
+        filterValue={filterValue}
+        groupTasks={grouping => {
+          secureLocalStorage.set('yourTasksGrouping', grouping);
+          groupYourTasks(grouping)
+        }}
+      />
+    );
+  }
 }
 
 YourTasksContainer.defaultProps = {
-    isFetchingTasks: true,
-    tasks: new List([]),
-    total: 0,
-    sortValue: 'sort=due,asc',
-    filterValue: null,
-    groupBy: 'category'
+  isFetchingTasks: true,
+  tasks: new List([]),
+  total: 0,
+  sortValue: 'sort=due,asc',
+  filterValue: null,
+  groupBy: 'category'
 };
 
 
 YourTasksContainer.propTypes = {
-    history: PropTypes.shape({
-        replace: PropTypes.func.isRequired
-    }).isRequired,
-    appConfig: PropTypes.shape({
-        uiEnvironment: PropTypes.string.isRequired
-    }).isRequired,
-    groupBy: PropTypes.string,
-    groupYourTasks: PropTypes.func.isRequired,
-    resetYourTasks: PropTypes.func.isRequired,
-    fetchTasksAssignedToYou: PropTypes.func.isRequired,
-    isFetchingTasks: PropTypes.bool,
-    tasks: ImmutablePropTypes.list,
-    total: PropTypes.number,
-    sortValue: PropTypes.string,
-    filterValue: PropTypes.string,
+  history: PropTypes.shape({
+    replace: PropTypes.func.isRequired
+  }).isRequired,
+  appConfig: PropTypes.shape({
+    uiEnvironment: PropTypes.string.isRequired
+  }).isRequired,
+  groupBy: PropTypes.string,
+  groupYourTasks: PropTypes.func.isRequired,
+  resetYourTasks: PropTypes.func.isRequired,
+  fetchTasksAssignedToYou: PropTypes.func.isRequired,
+  isFetchingTasks: PropTypes.bool,
+  tasks: ImmutablePropTypes.list,
+  total: PropTypes.number,
+  sortValue: PropTypes.string,
+  filterValue: PropTypes.string,
 };
 const mapDispatchToProps = dispatch => bindActionCreators(actions, dispatch);
 
 export default connect(state => ({
-    isFetchingTasks: isFetchingTasksSelector(state),
-    tasks: tasksSelector(state),
-    total: totalSelector(state),
-    sortValue: sortValueSelector(state),
-    filterValue: filterValueSelector(state),
-    groupBy: groupBySelector(state),
-    nextPageUrl: nextPageUrlSelector(state),
-    prevPageUrl: prevPageUrlSelector(state),
-    firstPageUrl: firstPageUrlSelector(state),
-    lastPageUrl: lastPageUrlSelector(state),
-    appConfig: state.appConfig,
-    kc: state.keycloak,
+  isFetchingTasks: isFetchingTasksSelector(state),
+  tasks: tasksSelector(state),
+  total: totalSelector(state),
+  sortValue: sortValueSelector(state),
+  filterValue: filterValueSelector(state),
+  groupBy: groupBySelector(state),
+  nextPageUrl: nextPageUrlSelector(state),
+  prevPageUrl: prevPageUrlSelector(state),
+  firstPageUrl: firstPageUrlSelector(state),
+  lastPageUrl: lastPageUrlSelector(state),
+  appConfig: state.appConfig,
+  kc: state.keycloak,
 }), mapDispatchToProps)(withRouter(YourTasksContainer));
-
-

--- a/app/pages/tasks/components/YourTasksContainer.jsx
+++ b/app/pages/tasks/components/YourTasksContainer.jsx
@@ -39,7 +39,12 @@ export class YourTasksContainer extends React.Component {
     }
 
     componentDidMount() {
-        this.loadYourTasks(false, 'sort=due,asc');
+
+        if (secureLocalStorage.get('yourTasksSorting')) {
+          this.loadYourTasks(false, secureLocalStorage.get('yourTasksSorting'));
+        } else {
+          this.loadYourTasks(false, 'sort=due,asc');
+        }
         if (secureLocalStorage.get('yourTasksGrouping')) {
             const {groupYourTasks} = this.props;
             groupYourTasks(secureLocalStorage.get('yourTasksGrouping'));
@@ -140,6 +145,7 @@ export class YourTasksContainer extends React.Component {
     }
 
     sortYourTasks(event) {
+        secureLocalStorage.set('yourTasksSorting', event.target.value);
         const {fetchTasksAssignedToYou, filterValue:filter} = this.props;
         fetchTasksAssignedToYou(event.target.value, filter, true);
     }


### PR DESCRIPTION
**AC**

When a user selects a sort order and refreshes or leaves the page and returns, the sort order should persist.
This is for both My Tasks and My Group Tasks

**To Test**

- log into COP
- go to Your Tasks
- select sort by 'Highest Priority'
- refresh page
> your sort order should remain as Highest Priority
- go back to Dashboard
- go to Your Tasks again
> your sort order should remain as Highest Priority

Repeat the above for Your Group Tasks