### PR TITLE
COP-1353 - Line manager details in Edit profile does not get read by screen reader

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -166,9 +166,9 @@
       }
     },
     "@digitalpatterns/formio-gds-template": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@digitalpatterns/formio-gds-template/-/formio-gds-template-1.5.0.tgz",
-      "integrity": "sha512-G4xUP4IcZyzCI7jXblDDS93p/kt1ZfzqQWdlVQBwSjiv2OcY84m8QUyAEFvmhGv3W/nqmp4uu49lxI2BNvopyg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@digitalpatterns/formio-gds-template/-/formio-gds-template-1.6.0.tgz",
+      "integrity": "sha512-C+nlSlyM7TJ2hvGCe7HXe7XlRCwnPm3aAx1NX32bAi4uV4sLuKxK4heIZ7vHypgeYyft0o7d2cx7MHxhsyyVYw==",
       "requires": {
         "govuk-frontend": "^3.6.0",
         "lodash": "^4.17.15"
@@ -13021,15 +13021,6 @@
       "version": "1.4.0",
       "resolved": "http://localhost:4873/powerbi-models/-/powerbi-models-1.4.0.tgz",
       "integrity": "sha512-SNdY3SSjOU1DHs3mgyvi2jv1UvTIXoxrbdZBEjsePQ7bo6Rp425Q6qKCE7kHgJz5fjOZ6tPU5+zT+J4J7xYFQQ=="
-    },
-    "powerbi-report-component": {
-      "version": "1.8.5",
-      "resolved": "http://localhost:4873/powerbi-report-component/-/powerbi-report-component-1.8.5.tgz",
-      "integrity": "sha512-T53i/pqvdnWmjW1zx3B2piSI7jcY0kkSYNfRuSqTLN2oMZJQaioK5D1FmSkFVwa1ZytApfEGq4ASYQGuD1ncug==",
-      "requires": {
-        "powerbi-client": "^2.11.0",
-        "prop-types": "^15.7.2"
-      }
     },
     "powerbi-router": {
       "version": "0.1.5",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "webpack-subresource-integrity": "^1.0.3"
   },
   "dependencies": {
-    "@digitalpatterns/formio-gds-template": "1.5.0",
+    "@digitalpatterns/formio-gds-template": "1.6.0",
     "@stomp/stompjs": "^5.4.2",
     "axios": "^0.19.0",
     "bootstrap": "^4.3.1",


### PR DESCRIPTION
Update `formio-gds-templates` version.

This update includes accessibility improvements for missing field labels.
Also associates labels with fields correctly using `id` and `for` attributes.