### PR TITLE
Fix/cop 2277 headings

### DIFF
--- a/app/core/components/AccessibilityStatement.jsx
+++ b/app/core/components/AccessibilityStatement.jsx
@@ -5,7 +5,7 @@ const AccessibilityStatement = () => (
     <main className="govuk-main-wrapper">
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-two-thirds">
-          <h1 className="govuk-heading-xl">
+          <h1 className="govuk-heading-l">
             Accessibility statement for Central Operations Platform (COP)
           </h1>
           <p className="govuk-body">
@@ -61,7 +61,7 @@ const AccessibilityStatement = () => (
             disability.
           </p>
 
-          <h2 className="govuk-heading-l">How accessible this website is</h2>
+          <h2 className="govuk-heading-m">How accessible this website is</h2>
           <p className="govuk-body">
             We aim to meet international accessibility guidelines. However, this
             may not always be possible, or we may have missed a problem.
@@ -121,7 +121,7 @@ const AccessibilityStatement = () => (
             Non-accessible content section of this statement.
           </p>
 
-          <h2 className="govuk-heading-l">Feedback and contact information</h2>
+          <h2 className="govuk-heading-m">Feedback and contact information</h2>
           <p className="govuk-body">
             If you have difficulty using this service, contact us by:
           </p>
@@ -142,7 +142,7 @@ const AccessibilityStatement = () => (
             <li>Calling the service desk on 0845 000 0050.</li>
           </ul>
 
-          <h2 className="govuk-heading-l">
+          <h2 className="govuk-heading-m">
             Reporting accessibility problems with this website
           </h2>
           <p className="govuk-body">
@@ -158,7 +158,7 @@ const AccessibilityStatement = () => (
             feedback and contact information section) to tell us.
           </p>
 
-          <h2 className="govuk-heading-l">Enforcement procedure</h2>
+          <h2 className="govuk-heading-m">Enforcement procedure</h2>
           <p className="govuk-body">
             The Equality and Human Rights Commission (EHRC) is responsible for
             enforcing the Public Sector Bodies (Websites and Mobile
@@ -190,7 +190,7 @@ const AccessibilityStatement = () => (
             ‘accessibility regulations’) in Northern Ireland.
           </p>
 
-          <h2 className="govuk-heading-l">
+          <h2 className="govuk-heading-m">
             Technical information about this website’s accessibility
           </h2>
           <p className="govuk-body">
@@ -199,7 +199,7 @@ const AccessibilityStatement = () => (
             Applications) (No. 2) Accessibility Regulations 2018.
           </p>
 
-          <h2 className="govuk-heading-l">Compliance status</h2>
+          <h2 className="govuk-heading-m">Compliance status</h2>
           <p className="govuk-body">
             This website is not compliant with the{' '}
             <a
@@ -213,13 +213,13 @@ const AccessibilityStatement = () => (
             AA standard. The non-compliances are listed below.
           </p>
 
-          <h2 className="govuk-heading-l">Non-accessible content</h2>
+          <h2 className="govuk-heading-m">Non-accessible content</h2>
           <p className="govuk-body">
             The content listed below is non-accessible for the following
             reasons.
           </p>
 
-          <h3 className="govuk-heading-m">
+          <h3 className="govuk-heading-s">
             Non-compliance with the accessibility regulations
           </h3>
           <ul className="govuk-list govuk-list--bullet">
@@ -320,7 +320,7 @@ const AccessibilityStatement = () => (
             </li>
           </ul>
 
-          <h3 className="govuk-heading-m">
+          <h3 className="govuk-heading-s">
             What we’re doing to improve accessibility
           </h3>
           <p className="govuk-body">
@@ -420,7 +420,7 @@ const AccessibilityStatement = () => (
             <li>(2.4.7) Ensure that scrollable region has keyboard access.</li>
           </ul>
 
-          <h3 className="govuk-heading-m">Disproportionate burden</h3>
+          <h3 className="govuk-heading-s">Disproportionate burden</h3>
           <p className="govuk-body">
             The National Security (CT) referral form on COP currently has a list
             of accessibility issues. The COP team are aware of this and will not
@@ -429,7 +429,7 @@ const AccessibilityStatement = () => (
             contact information section).
           </p>
 
-          <h3 className="govuk-heading-m">
+          <h3 className="govuk-heading-s">
             Content that’s not within the scope of the accessibility regulations
           </h3>
           <h4 className="govuk-heading-s">PDFs</h4>
@@ -442,7 +442,7 @@ const AccessibilityStatement = () => (
             scope of the accessibility regulations.
           </p>
 
-          <h2 className="govuk-heading-l">
+          <h2 className="govuk-heading-m">
             Preparation of this accessibility statement
           </h2>
           <p className="govuk-body">

--- a/app/core/components/PrivacyAndCookiePolicy.jsx
+++ b/app/core/components/PrivacyAndCookiePolicy.jsx
@@ -6,7 +6,7 @@ const PrivacyAndCookiePolicy = () => {
       <main className="govuk-main-wrapper">
         <div className="govuk-grid-row">
           <div className="govuk-grid-column-two-thirds">
-            <h1 className="govuk-heading-xl">
+            <h1 className="govuk-heading-l">
               Privacy notice for Home Office Workforce
             </h1>
             <p className="govuk-body">
@@ -25,7 +25,7 @@ const PrivacyAndCookiePolicy = () => {
               of COP. It does not extend to any websites that can be accessed
               from COP.
             </p>
-            <h2 className="govuk-heading-l">What data we need</h2>
+            <h2 className="govuk-heading-m">What data we need</h2>
             <p className="govuk-body">
               The personal data we collect from you on COP may include:
             </p>
@@ -63,7 +63,7 @@ const PrivacyAndCookiePolicy = () => {
               All information added to the platform is linked to your unique
               user ID for audit purposes.
             </p>
-            <h2 className="govuk-heading-l">Cookies</h2>
+            <h2 className="govuk-heading-m">Cookies</h2>
             <p className="govuk-body">
               COP uses cookies and you cannot access COP from a non-Home Office
               device.
@@ -109,7 +109,7 @@ const PrivacyAndCookiePolicy = () => {
               can be done by clicking Ctrl+H and navigating to the option to
               clear history, of which cookies can usually be found as a subset.
             </p>
-            <h2 className="govuk-heading-l">Why we need this data</h2>
+            <h2 className="govuk-heading-m">Why we need this data</h2>
             <p className="govuk-body">
               We use cookie information to enable you to log into the service
               that we provide and to link information you add into COP to your
@@ -141,7 +141,7 @@ const PrivacyAndCookiePolicy = () => {
               meeting the needs of its users and help us to make improvements to
               the site and service that we provide.
             </p>
-            <h2 className="govuk-heading-l">What we do with your data</h2>
+            <h2 className="govuk-heading-m">What we do with your data</h2>
             <p className="govuk-body">
               The data we collect may be shared with supplier organisations,
               other government departments, agencies and public bodies, but only
@@ -165,7 +165,7 @@ const PrivacyAndCookiePolicy = () => {
               website is visited, analytical information and session data
               temporarily stored for the visit.
             </p>
-            <h2 className="govuk-heading-l">How long we keep your data</h2>
+            <h2 className="govuk-heading-m">How long we keep your data</h2>
             <p className="govuk-body">
               We will only retain your personal data for as long as:
             </p>
@@ -178,7 +178,7 @@ const PrivacyAndCookiePolicy = () => {
               for the time you are a member of Border Force and then for a
               maximum of 5 years after you leave the Force.
             </p>
-            <h2 className="govuk-heading-l">
+            <h2 className="govuk-heading-m">
               Where your data is processed and stored
             </h2>
             <p className="govuk-body">
@@ -192,7 +192,7 @@ const PrivacyAndCookiePolicy = () => {
               notification email or SMS is stored in Notify for a maximum of 7
               days; this is stored within the European Economic Area (EEA).
             </p>
-            <h2 className="govuk-heading-l">
+            <h2 className="govuk-heading-m">
               How we protect your data and keep it secure
             </h2>
             <p className="govuk-body">
@@ -205,7 +205,7 @@ const PrivacyAndCookiePolicy = () => {
               We also make sure that any third parties that we deal with keep
               all personal data they process on our behalf secure.
             </p>
-            <h2 className="govuk-heading-l">What are your rights?</h2>
+            <h2 className="govuk-heading-m">What are your rights?</h2>
             <p className="govuk-body">You have the right to request:</p>
             <ul className="govuk-list govuk-list--bullet">
               <li>information about how your personal data is processed</li>
@@ -259,7 +259,7 @@ const PrivacyAndCookiePolicy = () => {
               </a>
               .
             </p>
-            <h2 className="govuk-heading-l">Changes to this notice</h2>
+            <h2 className="govuk-heading-m">Changes to this notice</h2>
             <p className="govuk-body">
               We may modify or amend this privacy notice at our discretion at
               any time. When we make changes to this notice, we will amend the

--- a/app/core/components/__snapshots__/AccessibilityStatement.test.jsx.snap
+++ b/app/core/components/__snapshots__/AccessibilityStatement.test.jsx.snap
@@ -14,7 +14,7 @@ exports[`Accessibility Statement page matches snapshot 1`] = `
         className="govuk-grid-column-two-thirds"
       >
         <h1
-          className="govuk-heading-xl"
+          className="govuk-heading-l"
         >
           Accessibility statement for Central Operations Platform (COP)
         </h1>
@@ -80,7 +80,7 @@ exports[`Accessibility Statement page matches snapshot 1`] = `
           has advice on making your device easier to use if you have a disability.
         </p>
         <h2
-          className="govuk-heading-l"
+          className="govuk-heading-m"
         >
           How accessible this website is
         </h2>
@@ -137,7 +137,7 @@ exports[`Accessibility Statement page matches snapshot 1`] = `
           We know some parts of this website are not fully accessible. You can see a full list of any issues we currently know about in the Non-accessible content section of this statement.
         </p>
         <h2
-          className="govuk-heading-l"
+          className="govuk-heading-m"
         >
           Feedback and contact information
         </h2>
@@ -172,7 +172,7 @@ exports[`Accessibility Statement page matches snapshot 1`] = `
           </li>
         </ul>
         <h2
-          className="govuk-heading-l"
+          className="govuk-heading-m"
         >
           Reporting accessibility problems with this website
         </h2>
@@ -187,7 +187,7 @@ exports[`Accessibility Statement page matches snapshot 1`] = `
           We’re always looking to improve the accessibility of our websites and services. If you find any problems or think we’re not meeting accessibility requirements, use the contact details above (in feedback and contact information section) to tell us.
         </p>
         <h2
-          className="govuk-heading-l"
+          className="govuk-heading-m"
         >
           Enforcement procedure
         </h2>
@@ -221,7 +221,7 @@ exports[`Accessibility Statement page matches snapshot 1`] = `
           who are responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the ‘accessibility regulations’) in Northern Ireland.
         </p>
         <h2
-          className="govuk-heading-l"
+          className="govuk-heading-m"
         >
           Technical information about this website’s accessibility
         </h2>
@@ -231,7 +231,7 @@ exports[`Accessibility Statement page matches snapshot 1`] = `
           The Home Office is committed to making its website accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.
         </p>
         <h2
-          className="govuk-heading-l"
+          className="govuk-heading-m"
         >
           Compliance status
         </h2>
@@ -251,7 +251,7 @@ exports[`Accessibility Statement page matches snapshot 1`] = `
           AA standard. The non-compliances are listed below.
         </p>
         <h2
-          className="govuk-heading-l"
+          className="govuk-heading-m"
         >
           Non-accessible content
         </h2>
@@ -261,7 +261,7 @@ exports[`Accessibility Statement page matches snapshot 1`] = `
           The content listed below is non-accessible for the following reasons.
         </p>
         <h3
-          className="govuk-heading-m"
+          className="govuk-heading-s"
         >
           Non-compliance with the accessibility regulations
         </h3>
@@ -327,7 +327,7 @@ exports[`Accessibility Statement page matches snapshot 1`] = `
           </li>
         </ul>
         <h3
-          className="govuk-heading-m"
+          className="govuk-heading-s"
         >
           What we’re doing to improve accessibility
         </h3>
@@ -433,7 +433,7 @@ exports[`Accessibility Statement page matches snapshot 1`] = `
           </li>
         </ul>
         <h3
-          className="govuk-heading-m"
+          className="govuk-heading-s"
         >
           Disproportionate burden
         </h3>
@@ -443,7 +443,7 @@ exports[`Accessibility Statement page matches snapshot 1`] = `
           The National Security (CT) referral form on COP currently has a list of accessibility issues. The COP team are aware of this and will not be making changes due to descoping this form soon, if you need any help with this form please contact us (please see feedback and contact information section).
         </p>
         <h3
-          className="govuk-heading-m"
+          className="govuk-heading-s"
         >
           Content that’s not within the scope of the accessibility regulations
         </h3>
@@ -463,7 +463,7 @@ exports[`Accessibility Statement page matches snapshot 1`] = `
           At this time, we have not identified any content that is not within scope of the accessibility regulations.
         </p>
         <h2
-          className="govuk-heading-l"
+          className="govuk-heading-m"
         >
           Preparation of this accessibility statement
         </h2>

--- a/app/core/components/__snapshots__/PrivacyAndCookiePolicy.test.jsx.snap
+++ b/app/core/components/__snapshots__/PrivacyAndCookiePolicy.test.jsx.snap
@@ -14,7 +14,7 @@ exports[`Privacy Policy page matches snapshot 1`] = `
         className="govuk-grid-column-two-thirds"
       >
         <h1
-          className="govuk-heading-xl"
+          className="govuk-heading-l"
         >
           Privacy notice for Home Office Workforce
         </h1>
@@ -34,7 +34,7 @@ exports[`Privacy Policy page matches snapshot 1`] = `
           This privacy policy applies only to the actions of COP and users of COP. It does not extend to any websites that can be accessed from COP.
         </p>
         <h2
-          className="govuk-heading-l"
+          className="govuk-heading-m"
         >
           What data we need
         </h2>
@@ -104,7 +104,7 @@ exports[`Privacy Policy page matches snapshot 1`] = `
           All information added to the platform is linked to your unique user ID for audit purposes.
         </p>
         <h2
-          className="govuk-heading-l"
+          className="govuk-heading-m"
         >
           Cookies
         </h2>
@@ -159,7 +159,7 @@ exports[`Privacy Policy page matches snapshot 1`] = `
           A user can remove cookies by deleting them from the browser. This can be done by clicking Ctrl+H and navigating to the option to clear history, of which cookies can usually be found as a subset.
         </p>
         <h2
-          className="govuk-heading-l"
+          className="govuk-heading-m"
         >
           Why we need this data
         </h2>
@@ -189,7 +189,7 @@ exports[`Privacy Policy page matches snapshot 1`] = `
           We use a service called Matomo to collect information about how you use the COP. We do this to help make sure that the site is meeting the needs of its users and help us to make improvements to the site and service that we provide.
         </p>
         <h2
-          className="govuk-heading-l"
+          className="govuk-heading-m"
         >
           What we do with your data
         </h2>
@@ -224,7 +224,7 @@ exports[`Privacy Policy page matches snapshot 1`] = `
           Information captured via cookies within Matomo includes a unique visitor ID, information to initially identify a user when a website is visited, analytical information and session data temporarily stored for the visit.
         </p>
         <h2
-          className="govuk-heading-l"
+          className="govuk-heading-m"
         >
           How long we keep your data
         </h2>
@@ -249,7 +249,7 @@ exports[`Privacy Policy page matches snapshot 1`] = `
           In general, this means that we will only hold your personal data for the time you are a member of Border Force and then for a maximum of 5 years after you leave the Force.
         </p>
         <h2
-          className="govuk-heading-l"
+          className="govuk-heading-m"
         >
           Where your data is processed and stored
         </h2>
@@ -264,7 +264,7 @@ exports[`Privacy Policy page matches snapshot 1`] = `
           We use GOV.UK Notify, a service provided by Cabinet Office to send you notifications about the COP. Any information included in the notification email or SMS is stored in Notify for a maximum of 7 days; this is stored within the European Economic Area (EEA).
         </p>
         <h2
-          className="govuk-heading-l"
+          className="govuk-heading-m"
         >
           How we protect your data and keep it secure
         </h2>
@@ -279,7 +279,7 @@ exports[`Privacy Policy page matches snapshot 1`] = `
           We also make sure that any third parties that we deal with keep all personal data they process on our behalf secure.
         </p>
         <h2
-          className="govuk-heading-l"
+          className="govuk-heading-m"
         >
           What are your rights?
         </h2>
@@ -349,7 +349,7 @@ exports[`Privacy Policy page matches snapshot 1`] = `
           .
         </p>
         <h2
-          className="govuk-heading-l"
+          className="govuk-heading-m"
         >
           Changes to this notice
         </h2>

--- a/app/pages/cases/components/CaseAttachments.jsx
+++ b/app/pages/cases/components/CaseAttachments.jsx
@@ -26,7 +26,7 @@ class CaseAttachments extends React.Component {
         return (
           <div className="govuk-grid-row govuk-card govuk-!-margin-top-4">
             <div className="govuk-grid-column-full">
-              <h3 className="govuk-heading-m">Case attachments</h3>
+              <h2 className="govuk-heading-m">Case attachments</h2>
               <details className="govuk-details" data-module="govuk-details">
                 <summary className="govuk-details__summary">
                   <span className="govuk-details__summary-text">
@@ -55,7 +55,7 @@ class CaseAttachments extends React.Component {
                       <tbody className="govuk-table__body">
                         {fetchingCaseAttachments ? (
                           <tr className="govuk-table__row">
-                            <td><h4 className="govuk-heading-s">Loading attachments...</h4></td>
+                            <td><h3 className="govuk-heading-s">Loading attachments...</h3></td>
                           </tr>
                                ): (attachments && attachments.length !== 0 ? attachments.map(attachment => {
                                     return (
@@ -96,9 +96,9 @@ class CaseAttachments extends React.Component {
                                       </tr>
 )
                                 }) : (
-                                  <h4 className="govuk-heading-s govuk-!-margin-top-4">
+                                  <h3 className="govuk-heading-s govuk-!-margin-top-4">
                                     No attachments associated with case
-                                  </h4>
+                                  </h3>
 ))}
 
                       </tbody>

--- a/app/pages/cases/components/CaseDetailsPanel.jsx
+++ b/app/pages/cases/components/CaseDetailsPanel.jsx
@@ -65,7 +65,7 @@ class CaseDetailsPanel extends React.Component {
               <div className="govuk-grid-column-full govuk-card">
                 <div className="govuk-grid-row">
                   <div className="govuk-grid-column-one-half">
-                    <h3 className="govuk-heading-m">{caseDetails.businessKey}</h3>
+                    <h3 className="govuk-heading-s">{caseDetails.businessKey}</h3>
                   </div>
                   <div className="govuk-grid-column-one-half">
                     <CopyToClipboard
@@ -85,7 +85,7 @@ class CaseDetailsPanel extends React.Component {
                  : null}
             <div className="govuk-grid-row govuk-card govuk-!-margin-top-4">
               <div className="govuk-grid-column-full">
-                <h3 className="govuk-heading-m">Case history</h3>
+                <h3 className="govuk-heading-s">Case history</h3>
                 <div className="govuk-form-group">
                   <label className="govuk-label" htmlFor="sort">
                                     Order by
@@ -133,7 +133,7 @@ class CaseDetailsPanel extends React.Component {
                                               <div className="govuk-grid-row">
                                                 <div className="govuk-grid-column-one-half">
                                                   <span className="govuk-caption-m">Status</span>
-                                                  <h3 className="govuk-heading-m"><span
+                                                  <h3 className="govuk-heading-s"><span
                                                     className="govuk-tag"
                                                   >{processInstance.endDate ? 'Completed' : 'Active'}
                                                                                   </span>
@@ -141,17 +141,17 @@ class CaseDetailsPanel extends React.Component {
                                                 </div>
                                                 <div className="govuk-grid-column-one-half">
                                                   <span className="govuk-caption-m">Forms</span>
-                                                  <h3 className="govuk-heading-m">{Object.keys(groupedForms).length} completed</h3>
+                                                  <h3 className="govuk-heading-s">{Object.keys(groupedForms).length} completed</h3>
 
                                                 </div>
                                                 <div className="govuk-grid-column-one-half">
                                                   <span className="govuk-caption-m">Start date</span>
-                                                  <h3 className="govuk-heading-m">{moment(processInstance.startDate).format('DD/MM/YYYY HH:mm')}</h3>
+                                                  <h3 className="govuk-heading-s">{moment(processInstance.startDate).format('DD/MM/YYYY HH:mm')}</h3>
                                                 </div>
                                                 <div className="govuk-grid-column-one-half">
                                                   <span className="govuk-caption-m">End date</span>
 
-                                                  <h3 className="govuk-heading-m">
+                                                  <h3 className="govuk-heading-s">
                                                     {processInstance.endDate ? moment(processInstance.endDate).format('DD/MM/YYYY HH:mm') :
                                                                     'Active'}
                                                   </h3>

--- a/app/pages/cases/components/CaseMetrics.jsx
+++ b/app/pages/cases/components/CaseMetrics.jsx
@@ -11,7 +11,7 @@ export default class CaseMetrics extends React.Component {
         return (
           <div className="govuk-grid-row govuk-card" id="caseMetrics">
             <div className="govuk-grid-column-full">
-              <h3 className="govuk-heading-m">Case metrics</h3>
+              <h3 className="govuk-heading-s">Case metrics</h3>
               <details className="govuk-details" data-module="govuk-details">
                 <summary className="govuk-details__summary">
                   <span className="govuk-details__summary-text">

--- a/app/pages/cases/components/CaseResultsPanel.jsx
+++ b/app/pages/cases/components/CaseResultsPanel.jsx
@@ -57,11 +57,13 @@ class CaseResultsPanel extends React.Component {
         return (
           <div className="govuk-grid-row">
             <div className="govuk-grid-column-one-quarter">
-              <h3 className="govuk-heading-m">Search results</h3>
+              <h2 className="govuk-heading-m">Search results</h2>
               {caseSearchResults ? (
                 <React.Fragment>
                   <span className="govuk-caption-m">Number of cases found</span>
-                  <h3 className="govuk-heading-m">{caseSearchResults.page.totalElements}</h3>
+                  <h3 className="govuk-heading-s">
+                    {caseSearchResults.page.totalElements}
+                  </h3>
 
                   {caseSearchResults.page.totalElements > 0 ? (
                     <ul className="govuk-list">

--- a/app/pages/cases/components/CaseResultsPanel.test.jsx
+++ b/app/pages/cases/components/CaseResultsPanel.test.jsx
@@ -84,6 +84,8 @@ describe('CaseResultsPanel', () => {
           </Provider>
         </Router>);
 
-        expect(wrapper.html()).toEqual('<div class="govuk-grid-row"><div class="govuk-grid-column-one-quarter"><h3 class="govuk-heading-m">Search results</h3><span class="govuk-caption-m">Number of cases found</span><h3 class="govuk-heading-m">2</h3><ul class="govuk-list"><li><a class="govuk-link" href="">businessKey1</a></li><li><a class="govuk-link" href="">businessKey2</a></li></ul></div><div class="govuk-grid-column-three-quarters"></div></div>')
+        expect(wrapper.html()).toEqual(
+          '<div class="govuk-grid-row"><div class="govuk-grid-column-one-quarter"><h2 class="govuk-heading-m">Search results</h2><span class="govuk-caption-m">Number of cases found</span><h3 class="govuk-heading-s">2</h3><ul class="govuk-list"><li><a class="govuk-link" href="">businessKey1</a></li><li><a class="govuk-link" href="">businessKey2</a></li></ul></div><div class="govuk-grid-column-three-quarters"></div></div>',
+        );
     })
 });

--- a/app/pages/cases/components/CasesPage.jsx
+++ b/app/pages/cases/components/CasesPage.jsx
@@ -45,9 +45,7 @@ class CasesPage extends React.Component {
         <div className="govuk-grid-row">
           <div className="govuk-grid-column-two-thirds">
             <span className="govuk-caption-l">Case view</span>
-            <h2 className="govuk-heading-l">
-              Cases
-            </h2>
+            <h1 className="govuk-heading-l">Cases</h1>
             <div className="govuk-inset-text">
               <p>Enter a COP number in quotes to search for cases—e.g. "COP-20200406-24".</p>
               <p><strong>Please note all actions are audited.</strong></p>

--- a/app/pages/cases/components/__snapshots__/CaseMetrics.test.jsx.snap
+++ b/app/pages/cases/components/__snapshots__/CaseMetrics.test.jsx.snap
@@ -9,7 +9,7 @@ exports[`CaseMetrics renders metrics 1`] = `
     className="govuk-grid-column-full"
   >
     <h3
-      className="govuk-heading-m"
+      className="govuk-heading-s"
     >
       Case metrics
     </h3>

--- a/app/pages/dashboard/components/DashboardTitle.jsx
+++ b/app/pages/dashboard/components/DashboardTitle.jsx
@@ -85,9 +85,7 @@ class DashboardTitle extends React.Component {
       <div className="govuk-grid-row govuk-!-padding-top-3">
         <div className="govuk-grid-column-one-half">
           <span className="govuk-caption-l">{kc.tokenParsed.given_name} {kc.tokenParsed.family_name}</span>
-          <h2 className="govuk-heading-l">
-            Operational dashboard
-          </h2>
+          <h1 className="govuk-heading-l">Operational dashboard</h1>
         </div>
         {shiftStatus()}
       </div>

--- a/app/pages/dashboard/components/NoOpDashboardPage.jsx
+++ b/app/pages/dashboard/components/NoOpDashboardPage.jsx
@@ -12,9 +12,7 @@ export class NoOpDashboardPage extends React.Component {
         <div className="govuk-grid-row" style={{ width: '100%', height: '230px' }}>
           <div className="govuk-grid-column-full">
             <span className="govuk-caption-l">{this.props.kc.tokenParsed.given_name} {this.props.kc.tokenParsed.family_name}</span>
-            <h2 className="govuk-heading-l">
-                    Operational dashboard
-            </h2>
+            <h1 className="govuk-heading-l">Operational dashboard</h1>
           </div>
           <div className="govuk-grid-column-full">
             <p className="govuk-body">Your onboarding onto COP is complete. We have sent you a confirmation email and text.</p>

--- a/app/pages/forms/list/components/FormsListPage.jsx
+++ b/app/pages/forms/list/components/FormsListPage.jsx
@@ -42,9 +42,9 @@ export class FormsListPage extends React.Component {
         <div className="govuk-grid-row" id="proceduresCountLabel">
           <div className="govuk-grid-column-one-half">
             <span className="govuk-caption-l">Operational forms</span>
-            <h2 className="govuk-heading-l">
+            <h1 className="govuk-heading-l">
               {processDefinitions.size} forms
-            </h2>
+            </h1>
           </div>
         </div>
         <div className="govuk-grid-row">

--- a/app/pages/forms/start/components/FormsStartPage.jsx
+++ b/app/pages/forms/start/components/FormsStartPage.jsx
@@ -245,9 +245,9 @@ export class ProcessStartPage extends React.Component {
             <div className="govuk-grid-column-full">
               <div>
                 <span className="govuk-caption-l">Operational form</span>
-                <h2 className="govuk-heading-l">
+                <h1 className="govuk-heading-l">
                   {processDefinition.getIn(['process-definition', 'name'])}
-                </h2>
+                </h1>
                 {this.props.submissionResponse &&
                 this.props.submissionResponse.tasks &&
                 this.props.submissionResponse.tasks.length !== 0 ? (

--- a/app/pages/forms/start/components/__snapshots__/FormsStartPage.test.jsx.snap
+++ b/app/pages/forms/start/components/__snapshots__/FormsStartPage.test.jsx.snap
@@ -55,11 +55,11 @@ exports[`Submit a form page renders the form and process definition 1`] = `
           >
             Operational form
           </span>
-          <h2
+          <h1
             className="govuk-heading-l"
           >
             procedure
-          </h2>
+          </h1>
           <StartForm
             appConfig={
               Object {

--- a/app/pages/messages/components/MessagesPage.jsx
+++ b/app/pages/messages/components/MessagesPage.jsx
@@ -54,9 +54,9 @@ export class MessagesPage extends React.Component {
           <div className="govuk-grid-row" id="numberOfMessages">
             <div className="govuk-grid-column-one-half">
               <span className="govuk-caption-l">Operational messages</span>
-              <h2 className="govuk-heading-l">
+              <h1 className="govuk-heading-l">
                 {this.props.total} messages
-              </h2>
+              </h1>
             </div>
           </div>
         )}
@@ -112,7 +112,7 @@ const NotificationTask = ({ task, action }) => {
         <span className="govuk-caption-m" id="messageCreated">
           {created(task)}
         </span>
-        <h3 className="govuk-heading-m" id="messageName">
+        <h2 className="govuk-heading-m" id="messageName">
           {taskPriority >= 100 && taskPriority <= 1000 ? (
             <div className="govuk-warning-text ">
               <span
@@ -132,7 +132,7 @@ const NotificationTask = ({ task, action }) => {
               {determineTitle(task)}: {taskName}
             </div>
           )}
-        </h3>
+        </h2>
         <div className="govuk-card__content">
           <p className="govuk-body"> {taskDescription}</p>
         </div>

--- a/app/pages/messages/components/MessagesPage.test.jsx
+++ b/app/pages/messages/components/MessagesPage.test.jsx
@@ -102,7 +102,7 @@ describe('MessagesPage', () => {
     expect(messagesCountWrapper.text()).toEqual('Operational messages1 messages');
 
     const flashCardWrapper = wrapper.find('#messageName');
-    expect(flashCardWrapper.find('h3').text()).toEqual(
+    expect(flashCardWrapper.find('h2').text()).toEqual(
       '!WarningEmergency: name',
     );
     expect(wrapper.find('#messageCreated').text()).toEqual('a few seconds ago');

--- a/app/pages/reports/components/ReportsPage.jsx
+++ b/app/pages/reports/components/ReportsPage.jsx
@@ -29,7 +29,7 @@ export class ReportsPage extends React.Component {
         items.push(
           <div id="report" className="govuk-grid-row" key={uuid()}>
             <div className="govuk-grid-column-full govuk-card">
-              <h3 className="govuk-heading-m">{report.get('name')}</h3>
+              <h2 className="govuk-heading-m">{report.get('name')}</h2>
               <p id="formDescription" className="govuk-body">
                 {report.get('description')}
               </p>
@@ -71,9 +71,9 @@ export class ReportsPage extends React.Component {
         <div className="govuk-grid-row" id="reportsCountLabel">
           <div className="govuk-grid-column-one-half">
             <span className="govuk-caption-l">Operational reports</span>
-            <h2 className="govuk-heading-l">
+            <h1 className="govuk-heading-l">
               {reportsList.size} {reportsList.size === 1 ? 'report' : 'reports'}
-            </h2>
+            </h1>
           </div>
         </div>
         {reportsLoading ? (

--- a/app/pages/reports/components/__snapshots__/ReportsPage.test.jsx.snap
+++ b/app/pages/reports/components/__snapshots__/ReportsPage.test.jsx.snap
@@ -14,13 +14,13 @@ exports[`Reports Page matches snapshot 1`] = `
       >
         Operational reports
       </span>
-      <h2
+      <h1
         className="govuk-heading-l"
       >
         0
          
         reports
-      </h2>
+      </h1>
     </div>
   </div>
   <div

--- a/app/pages/task/display/component/TaskTitle.jsx
+++ b/app/pages/task/display/component/TaskTitle.jsx
@@ -44,9 +44,9 @@ const TaskTitle = props => {
           <span className="govuk-caption-l">
             <Link className="govuk-link" target="_blank" to={`/cases/${businessKey}`}>{businessKey}</Link>
           </span>
-          <h2 className="govuk-heading-l">
+          <h1 className="govuk-heading-l">
             {task.get('name')}
-          </h2>
+          </h1>
         </div>
       </div>
       <div className="govuk-grid-row">

--- a/app/pages/tasks/components/YourGroupTasks.jsx
+++ b/app/pages/tasks/components/YourGroupTasks.jsx
@@ -40,9 +40,9 @@ const YourGroupTasks = props => {
                 borderTop: 'none',
               }}
               />
-              <h3 className="govuk-heading-m">
+              <h2 className="govuk-heading-m">
                 {`${key} ${value.length} ${tasks}`}
-              </h3>
+              </h2>
             </React.Fragment>
           )}
           {_.map(value, val => {
@@ -147,9 +147,9 @@ const YourGroupTasks = props => {
             id="yourGroupTasksTotalCount"
           >
             <span className="govuk-caption-l">Your team&rsquo;s tasks</span>
-            <h2 className="govuk-heading-l">
+            <h1 className="govuk-heading-l">
               {totalTasks} assigned to your team
-            </h2>
+            </h1>
             <div className="govuk-inset-text">
               <strong>This page auto refreshes every 5 minutes</strong>
             </div>

--- a/app/pages/tasks/components/YourTasks.jsx
+++ b/app/pages/tasks/components/YourTasks.jsx
@@ -37,9 +37,9 @@ const YourTasks = props => {
                 borderTop: 'none',
               }}
               />
-              <h3 className="govuk-heading-m">
+              <h2 className="govuk-heading-m">
                 {`${key} ${value.length} ${tasks}`}
-              </h3>
+              </h2>
             </React.Fragment>
           )}
           {_.map(value, val => {
@@ -111,9 +111,9 @@ const YourTasks = props => {
         <div className="govuk-grid-row">
           <div className="govuk-grid-column-one-half" id="yourTasksTotalCount">
             <span className="govuk-caption-l">Your tasks</span>
-            <h2 className="govuk-heading-l">
+            <h1 className="govuk-heading-l">
               {totalTasks} assigned to you
-            </h2>
+            </h1>
           </div>
         </div>
         <div className="govuk-grid-row govuk-!-padding-top-3">


### PR DESCRIPTION
Update headings to go from `h1` downward using `govuk-heading-` classes `large`, `medium` and `small` accordingly.