### PR TITLE
COP 2215 Enhance the tasklists so that users can group tasks by assignee

### DIFF
--- a/app/pages/tasks/components/GroupTasks.jsx
+++ b/app/pages/tasks/components/GroupTasks.jsx
@@ -17,6 +17,7 @@ const GroupTasks = ({groupTasks, grouping}) => {
           <option value="category">Category</option>
           <option value="reference">BF Reference</option>
           <option value="priority">Priority</option>
+          <option value="assignee">Assignee</option>
         </select>
       </div>
 )};

--- a/app/pages/tasks/components/TaskUtils.js
+++ b/app/pages/tasks/components/TaskUtils.js
@@ -54,6 +54,11 @@ export default class TaskUtils {
     const byPriority = _.groupBy(tasks, key => {
       return priority(Number(` ${key.task.priority}`)).trim();
     });
+
+    const byAssignee = _.groupBy(tasks, data => {
+      return data['task'].assignee;
+    });
+
     const sortByKeys = object => {
       const sort = _.orderBy(
         Object.keys(object),
@@ -89,6 +94,9 @@ export default class TaskUtils {
           }),
         );
 
+      case 'assignee':
+        return sortByKeys(byAssignee);
+
       default:
         return sortByKeys(
           _.groupBy(tasks, data => {
@@ -105,6 +113,7 @@ export default class TaskUtils {
     switch (grouping) {
       case 'category':
       case 'priority':
+      case 'assignee':
         caption = val.businessKey;
         break;
       case 'reference':

--- a/app/pages/tasks/components/YourGroupTasks.jsx
+++ b/app/pages/tasks/components/YourGroupTasks.jsx
@@ -40,9 +40,9 @@ const YourGroupTasks = props => {
                 borderTop: 'none',
               }}
               />
-              <h2 className="govuk-heading-m">
-                {`${key} ${value.length} ${tasks}`}
-              </h2>
+              <h3 className="govuk-heading-m">
+                {`${key === 'null' ? 'Unassigned' : key} ${value.length} ${tasks}`}
+              </h3>
             </React.Fragment>
           )}
           {_.map(value, val => {

--- a/app/pages/tasks/components/YourGroupTasks.jsx
+++ b/app/pages/tasks/components/YourGroupTasks.jsx
@@ -26,7 +26,6 @@ const YourGroupTasks = props => {
     paginationActions
   } = props;
 
-
   const dataToDisplay = _.map(yourGroupTasks, (value, key) => {
     const tasks = value.length === 1 ? 'task' : 'tasks';
     return (
@@ -41,7 +40,7 @@ const YourGroupTasks = props => {
               }}
               />
               <h3 className="govuk-heading-m">
-                {`${key === 'null' ? 'Unassigned' : key} ${value.length} ${tasks}`}
+                {`${key === 'null' && grouping === 'assignee' ? 'Unassigned' : key} ${value.length} ${tasks}`}
               </h3>
             </React.Fragment>
           )}


### PR DESCRIPTION
### AC
Allow the user to group tasks by assignee

### Updated
- Added option of "Assignee" on "Group by" for tasks

### Notes
- If a task has a null assignee, 'Unassigned' is rendered as opposed to 'null'
- Business key is used as the caption for each item within each group

### To test
- Create 2 Event at the Border tasks (does not matter what type)
- Claim one of the tasks (do not proceed to fill out form, return to dashboard)
- Open your group task list
- Group by 'Assignee'
- You should see `<your@email> 1 task` as one group
- You should see `Unassigned 1 task` as another separate group

