### PR TITLE
COP-1219 Prevent form rendering in case actions immediately after submission

### DIFF
--- a/app/pages/cases/case-actions/components/CaseAction.jsx
+++ b/app/pages/cases/case-actions/components/CaseAction.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import {Form} from "react-formio";
+import { Form } from "react-formio";
 import PropTypes from "prop-types";
-import {bindActionCreators} from "redux";
-import {withRouter} from "react-router";
-import {connect} from "react-redux";
-import {fetchActionForm, resetSelectedAction, executeAction, clearActionResponse} from "../actions";
-import {actionForm, actionResponse, executingAction, loadingActionForm} from "../selectors";
+import { bindActionCreators } from "redux";
+import { withRouter } from "react-router";
+import { connect } from "react-redux";
+import { fetchActionForm, resetSelectedAction, executeAction, clearActionResponse } from "../actions";
+import { actionForm, actionResponse, executingAction, loadingActionForm } from "../selectors";
 import withLog from "../../../../core/error/component/withLog";
 import FormioInterpolator from "../../../../core/FormioInterpolator";
 import secureLocalStorage from "../../../../common/security/SecureLocalStorage";
@@ -13,189 +13,189 @@ import FileService from "../../../../core/FileService";
 import { getCaseByKey } from '../../actions';
 
 class CaseAction extends React.Component {
-    constructor(props) {
-        super(props);
-        this.formioInterpolator = new FormioInterpolator();
+  constructor(props) {
+    super(props);
+    this.formioInterpolator = new FormioInterpolator();
+  }
+
+  componentDidMount() {
+    if (this.props.selectedAction) {
+      this.props.fetchActionForm(this.props.selectedAction.process.formKey);
+    }
+  }
+
+  componentDidUpdate(prevProps, prevState, snapshot) {
+    if (this.props.selectedAction.process['process-definition'].key !==
+      prevProps.selectedAction.process['process-definition'].key) {
+      this.props.clearActionResponse();
+      this.props.fetchActionForm(this.props.selectedAction.process.formKey);
+    }
+    if (this.props.actionResponse) {
+      const that = this;
+      this.timer = setTimeout(() => {
+        that.props.clearActionResponse();
+        this.props.getCaseByKey(this.props.caseDetails.businessKey);
+      }, 5000);
+    }
+  }
+
+  componentWillUnmount() {
+    this.props.resetSelectedAction();
+    if (this.timer) {
+      clearTimeout(this.timer);
+    }
+  }
+
+  render() {
+    const {
+      selectedAction, caseDetails,
+      loadingActionForm, actionForm, kc, appConfig,
+      executingAction, actionResponse
+    } = this.props;
+    if (!selectedAction || !caseDetails) {
+      return <div id="emptyAction" />
+    }
+    if (loadingActionForm) {
+      return <div id="loadingActionForm">Loading</div>
+    }
+    if (!actionForm) {
+      return <div id="emptyForm" />
     }
 
-    componentDidMount() {
-        if (this.props.selectedAction) {
-            this.props.fetchActionForm(this.props.selectedAction.process.formKey);
-        }
+    if (executingAction) {
+      return <div id="submittingAction">Submitting action...</div>
     }
 
-    componentDidUpdate(prevProps, prevState, snapshot) {
-        if (this.props.selectedAction.process['process-definition'].key !==
-            prevProps.selectedAction.process['process-definition'].key) {
-            this.props.clearActionResponse();
-            this.props.fetchActionForm(this.props.selectedAction.process.formKey);
-        }
-        if (this.props.actionResponse) {
-            const that = this;
-            this.timer = setTimeout(() => {
-                that.props.clearActionResponse();
-                this.props.getCaseByKey(this.props.caseDetails.businessKey);
-            }, 5000);
-        }
-    }
+    const submission = {
+      caseDetails,
+      selectedAction,
+      keycloakContext: {
+        accessToken: kc.token,
+        refreshToken: kc.refreshToken,
+        sessionId: kc.tokenParsed.session_state,
+        email: kc.tokenParsed.email,
+        givenName: kc.tokenParsed.given_name,
+        familyName: kc.tokenParsed.family_name
+      },
+      shiftDetailsContext: secureLocalStorage.get('shift'),
+      staffDetailsDataContext: secureLocalStorage.get(`staffContext::${kc.tokenParsed.email}`),
+      extendedStaffDetailsContext: secureLocalStorage.get('extendedStaffDetails'),
+      environmentContext: {
+        referenceDataUrl: appConfig.apiRefUrl,
+        workflowUrl: appConfig.workflowServiceUrl,
+        operationalDataUrl: appConfig.operationalDataUrl,
+        privateUiUrl: window.location.origin,
+        attachmentServiceUrl: appConfig.attachmentServiceUrl
+      }
+    };
 
-    componentWillUnmount() {
-        this.props.resetSelectedAction();
-        if (this.timer) {
-            clearTimeout(this.timer);
-        }
-    }
-
-    render() {
-        const {
-            selectedAction, caseDetails,
-            loadingActionForm, actionForm, kc, appConfig,
-            executingAction, actionResponse
-        } = this.props;
-        if (!selectedAction || !caseDetails) {
-            return <div id="emptyAction" />
-        }
-        if (loadingActionForm) {
-            return <div id="loadingActionForm">Loading</div>
-        }
-        if (!actionForm) {
-            return <div id="emptyForm" />
-        }
-
-        if (executingAction) {
-            return <div id="submittingAction">Submitting action...</div>
-        }
-
-        const submission = {
-            caseDetails,
-            selectedAction,
-            keycloakContext: {
-                accessToken: kc.token,
-                refreshToken: kc.refreshToken,
-                sessionId: kc.tokenParsed.session_state,
-                email: kc.tokenParsed.email,
-                givenName: kc.tokenParsed.given_name,
-                familyName: kc.tokenParsed.family_name
-            },
-            shiftDetailsContext: secureLocalStorage.get('shift'),
-            staffDetailsDataContext: secureLocalStorage.get(`staffContext::${kc.tokenParsed.email}`),
-            extendedStaffDetailsContext: secureLocalStorage.get('extendedStaffDetails'),
-            environmentContext: {
-                referenceDataUrl: appConfig.apiRefUrl,
-                workflowUrl: appConfig.workflowServiceUrl,
-                operationalDataUrl: appConfig.operationalDataUrl,
-                privateUiUrl: window.location.origin,
-                attachmentServiceUrl: appConfig.attachmentServiceUrl
-            }
-        };
-
-        this.formioInterpolator.interpolate(actionForm, submission);
-        return (
-          <div>
-            {actionResponse ? (
-              <div className="govuk-panel govuk-panel--confirmation">
-                <div className="govuk-panel__body govuk-!-font-size-24 govuk-!-font-weight-bold">
-                  {selectedAction.completionMessage}
-                </div>
-              </div>
-            )
-                : 
-            (
-              <Form
-                form={actionForm}
-                options={{
-                        noAlerts: true,
-                        fileService: new FileService(kc),
-                        readOnly: this.props.executingAction,
-                        hooks: {
-                            beforeSubmit: (submission, next) => {
-                                ['keycloakContext',
-                                    'staffDetailsDataContext',
-                                    'selectedAction',
-                                    'caseDetails']
-                                    .forEach(k => {
-                                        delete submission.data[k];
-                                    });
-                                submission.data.form = {
-                                    formVersionId: actionForm.versionId,
-                                    formId: actionForm.id,
-                                    title: actionForm.title,
-                                    name: actionForm.name,
-                                    submittedBy: kc.tokenParsed.email,
-                                    submissionDate: new Date(),
-                                    process: {
-                                        definitionId: selectedAction.process['process-definition'].id
-                                    }
-                                };
-                                next();
-                            }
-                        }
-                    }}
-                submission={{
-                        data: submission
-                    }}
-                onSubmit={
-                        submission => {
-                            if (!this.props.executingAction) {
-                                this.props.executeAction(
-                                    selectedAction,
-                                    submission.data,
-                                    caseDetails
-                                );
-                            }
-                        }
-                    }
-              />
-            )}
+    this.formioInterpolator.interpolate(actionForm, submission);
+    return (
+      <div>
+        {actionResponse ? (
+          <div className="govuk-panel govuk-panel--confirmation">
+            <div className="govuk-panel__body govuk-!-font-size-24 govuk-!-font-weight-bold">
+              {selectedAction.completionMessage}
+            </div>
           </div>
-)
-    }
+        )
+          :
+          (
+            <Form
+              form={actionForm}
+              options={{
+                noAlerts: true,
+                fileService: new FileService(kc),
+                readOnly: this.props.executingAction,
+                hooks: {
+                  beforeSubmit: (submission, next) => {
+                    ['keycloakContext',
+                      'staffDetailsDataContext',
+                      'selectedAction',
+                      'caseDetails']
+                      .forEach(k => {
+                        delete submission.data[k];
+                      });
+                    submission.data.form = {
+                      formVersionId: actionForm.versionId,
+                      formId: actionForm.id,
+                      title: actionForm.title,
+                      name: actionForm.name,
+                      submittedBy: kc.tokenParsed.email,
+                      submissionDate: new Date(),
+                      process: {
+                        definitionId: selectedAction.process['process-definition'].id
+                      }
+                    };
+                    next();
+                  }
+                }
+              }}
+              submission={{
+                data: submission
+              }}
+              onSubmit={
+                submission => {
+                  if (!this.props.executingAction) {
+                    this.props.executeAction(
+                      selectedAction,
+                      submission.data,
+                      caseDetails
+                    );
+                  }
+                }
+              }
+            />
+          )}
+      </div>
+    )
+  }
 }
 
 CaseAction.propTypes = {
-    clearActionResponse: PropTypes.func,
-    appConfig: PropTypes.object,
-    executingAction: PropTypes.bool,
-    actionResponse: PropTypes.object,
-    executeAction: PropTypes.func,
-    resetSelectedAction: PropTypes.func,
-    actionForm: PropTypes.object,
-    fetchActionForm: PropTypes.func,
-    loadingActionForm: PropTypes.bool,
-    kc: PropTypes.object,
-    caseDetails: PropTypes.shape({
-        businessKey: PropTypes.string
-    }),
-    selectedAction: PropTypes.shape({
-        completionMessage: PropTypes.string,
-        process: PropTypes.shape({
-            formKey: PropTypes.string,
-            'process-definition': PropTypes.shape({
-                id: PropTypes.string,
-                key: PropTypes.string,
-                description: PropTypes.string,
-                name: PropTypes.string
-            })
-        })
+  clearActionResponse: PropTypes.func,
+  appConfig: PropTypes.object,
+  executingAction: PropTypes.bool,
+  actionResponse: PropTypes.object,
+  executeAction: PropTypes.func,
+  resetSelectedAction: PropTypes.func,
+  actionForm: PropTypes.object,
+  fetchActionForm: PropTypes.func,
+  loadingActionForm: PropTypes.bool,
+  kc: PropTypes.object,
+  caseDetails: PropTypes.shape({
+    businessKey: PropTypes.string
+  }),
+  selectedAction: PropTypes.shape({
+    completionMessage: PropTypes.string,
+    process: PropTypes.shape({
+      formKey: PropTypes.string,
+      'process-definition': PropTypes.shape({
+        id: PropTypes.string,
+        key: PropTypes.string,
+        description: PropTypes.string,
+        name: PropTypes.string
+      })
     })
+  })
 };
 
 
 const mapDispatchToProps = dispatch => bindActionCreators({
-    fetchActionForm,
-    resetSelectedAction, executeAction, clearActionResponse,
-    getCaseByKey
+  fetchActionForm,
+  resetSelectedAction, executeAction, clearActionResponse,
+  getCaseByKey
 }, dispatch);
 
 export default withRouter(connect(state => {
-    return {
-        kc: state.keycloak,
-        appConfig: state.appConfig,
-        loadingActionForm: loadingActionForm(state),
-        actionForm: actionForm(state),
-        executingAction: executingAction(state),
-        actionResponse: actionResponse(state)
-    }
+  return {
+    kc: state.keycloak,
+    appConfig: state.appConfig,
+    loadingActionForm: loadingActionForm(state),
+    actionForm: actionForm(state),
+    executingAction: executingAction(state),
+    actionResponse: actionResponse(state)
+  }
 }, mapDispatchToProps)(withLog(CaseAction)));
 
 

--- a/app/pages/cases/case-actions/components/CaseAction.jsx
+++ b/app/pages/cases/case-actions/components/CaseAction.jsx
@@ -10,6 +10,7 @@ import withLog from "../../../../core/error/component/withLog";
 import FormioInterpolator from "../../../../core/FormioInterpolator";
 import secureLocalStorage from "../../../../common/security/SecureLocalStorage";
 import FileService from "../../../../core/FileService";
+import { getCaseByKey } from '../../actions';
 
 class CaseAction extends React.Component {
     constructor(props) {
@@ -33,6 +34,7 @@ class CaseAction extends React.Component {
             const that = this;
             this.timer = setTimeout(() => {
                 that.props.clearActionResponse();
+                this.props.getCaseByKey(this.props.caseDetails.businessKey);
             }, 5000);
         }
     }
@@ -96,53 +98,55 @@ class CaseAction extends React.Component {
                   {selectedAction.completionMessage}
                 </div>
               </div>
-)
-                : null}
-            <Form
-              form={actionForm}
-              options={{
-                      noAlerts: true,
-                      fileService: new FileService(kc),
-                      readOnly: this.props.executingAction,
-                      hooks: {
-                          beforeSubmit: (submission, next) => {
-                              ['keycloakContext',
-                                  'staffDetailsDataContext',
-                                  'selectedAction',
-                                  'caseDetails']
-                                  .forEach(k => {
-                                      delete submission.data[k];
-                                  });
-                              submission.data.form = {
-                                  formVersionId: actionForm.versionId,
-                                  formId: actionForm.id,
-                                  title: actionForm.title,
-                                  name: actionForm.name,
-                                  submittedBy: kc.tokenParsed.email,
-                                  submissionDate: new Date(),
-                                  process: {
-                                      definitionId: selectedAction.process['process-definition'].id
-                                  }
-                              };
-                              next();
-                          }
-                      }
-                  }}
-              submission={{
-                      data: submission
-                  }}
-              onSubmit={
-                      submission => {
-                          if (!this.props.executingAction) {
-                              this.props.executeAction(
-                                  selectedAction,
-                                  submission.data,
-                                  caseDetails
-                              );
-                          }
-                      }
-                  }
-            />
+            )
+                : 
+            (
+              <Form
+                form={actionForm}
+                options={{
+                        noAlerts: true,
+                        fileService: new FileService(kc),
+                        readOnly: this.props.executingAction,
+                        hooks: {
+                            beforeSubmit: (submission, next) => {
+                                ['keycloakContext',
+                                    'staffDetailsDataContext',
+                                    'selectedAction',
+                                    'caseDetails']
+                                    .forEach(k => {
+                                        delete submission.data[k];
+                                    });
+                                submission.data.form = {
+                                    formVersionId: actionForm.versionId,
+                                    formId: actionForm.id,
+                                    title: actionForm.title,
+                                    name: actionForm.name,
+                                    submittedBy: kc.tokenParsed.email,
+                                    submissionDate: new Date(),
+                                    process: {
+                                        definitionId: selectedAction.process['process-definition'].id
+                                    }
+                                };
+                                next();
+                            }
+                        }
+                    }}
+                submission={{
+                        data: submission
+                    }}
+                onSubmit={
+                        submission => {
+                            if (!this.props.executingAction) {
+                                this.props.executeAction(
+                                    selectedAction,
+                                    submission.data,
+                                    caseDetails
+                                );
+                            }
+                        }
+                    }
+              />
+            )}
           </div>
 )
     }
@@ -179,7 +183,8 @@ CaseAction.propTypes = {
 
 const mapDispatchToProps = dispatch => bindActionCreators({
     fetchActionForm,
-    resetSelectedAction, executeAction, clearActionResponse
+    resetSelectedAction, executeAction, clearActionResponse,
+    getCaseByKey
 }, dispatch);
 
 export default withRouter(connect(state => {


### PR DESCRIPTION
### AC
User should not be able to submit multiple Stop SLA forms for one case.

### Updated
- Updated `CaseAction.jsx` to fetch for the most up-to-date case 5 seconds after a case action form has been submitted (within the same `setTimeout` as the code that removes the case action response message).
- Instead of rendering null if `actionResponse` is false, it renders the case action form. 

### Notes
- `actionResponse` is only ever truthy when a successful form submission has taken place and only the successful submission message is rendered without the form.
- If the form submission fails - the form will persist without requiring the user to refresh the page.
- The changes now prevent any case action form from being submitted after a user has just submitted a case form successfully - not just Stop SLA

### To test
*Scenario 1:*
- Submit form with 'intelligence officer report' information type
- Find the above task in case view
- Expand case actions
- Submit a 'Stop SLA' form
- If form submission successful, for 5 seconds you should only see the message 'Stop SLA successfully triggered' and not the form you have just submitted
- After 5 seconds, the updated case should be rendered and the Stop SLA tab should not be present in the case action tabs list

*Scenario 2*:
- Submit form with 'intelligence officer report' information type
- Find the above task in case view
- Expand case actions
- Submit 'Record Actions' case action form
- If form submission successful, for 5 seconds you should only see the message 'Record actions successfully triggered' and not the form you have just submitted
- After 5 seconds, the updated case should be rendered and the Record actions tab should be present in the case action tabs list