### PR TITLE
Add groups to keycloakContext in TaskForm so it's available to the task forms

### DIFF
--- a/app/pages/task/form/components/TaskForm.jsx
+++ b/app/pages/task/form/components/TaskForm.jsx
@@ -120,6 +120,7 @@ export default class TaskForm extends React.Component {
         subject: kc.subject,
         url: kc.authServerUrl,
         realm: kc.realm,
+        groups: kc.tokenParsed.groups,
       },
       shiftDetailsContext: secureLocalStorage.get('shift'),
       staffDetailsDataContext: secureLocalStorage.get(

--- a/app/pages/task/form/components/TaskForm.test.jsx
+++ b/app/pages/task/form/components/TaskForm.test.jsx
@@ -25,6 +25,7 @@ describe('TaskForm Component', () => {
           family_name: 'test',
           given_name: 'name',
           session_state: 'state',
+          groups: ['/group/one', '/group/two']
         },
       },
       onCustomEvent: jest.fn(),

--- a/app/pages/task/form/components/__snapshots__/TaskForm.test.jsx.snap
+++ b/app/pages/task/form/components/__snapshots__/TaskForm.test.jsx.snap
@@ -135,6 +135,10 @@ exports[`TaskForm Component matches snapshot 1`] = `
             "email": "yesy",
             "family_name": "test",
             "given_name": "name",
+            "groups": Array [
+              "/group/one",
+              "/group/two",
+            ],
             "session_state": "state",
           },
           "url": "http://localhost",
@@ -169,6 +173,10 @@ exports[`TaskForm Component matches snapshot 1`] = `
           "email": "yesy",
           "familyName": "test",
           "givenName": "name",
+          "groups": Array [
+            "/group/one",
+            "/group/two",
+          ],
           "realm": "cop-test",
           "refreshToken": undefined,
           "sessionId": "state",


### PR DESCRIPTION
Add groups from the user's token to `keycloakContext` in `TaskForm` so it's available to the task forms

This will be used in the E@B people form so we can populate the IS81 groups dropdown box with the data that we already have in the token and therefore removes the need to do an additional API call to get these values.

Also by not calling the Keycloak API we no longer have the permissions issue of trying to call the API from the UI.