### PR TITLE
Check data is returned in the response from the staff details API call before trying to return the staff id

### DIFF
--- a/app/core/shift/OnboardChecker.js
+++ b/app/core/shift/OnboardChecker.js
@@ -1,6 +1,6 @@
 export default class OnboardChecker {
   static onBoardCheck(staffDetails, location) {
-    if (!staffDetails) {
+    if (!staffDetails.staffid) {
       return {
         redirectPath: '/onboard-user',
         data: {

--- a/app/core/shift/OnboardChecker.test.js
+++ b/app/core/shift/OnboardChecker.test.js
@@ -3,7 +3,7 @@ import OnboardChecker from './OnboardChecker';
 
 describe('OnboardChecker', () => {
   it('onboard-user for new user', () => {
-    const staffDetails = null;
+    const staffDetails = {};
 
     const response = OnboardChecker.onBoardCheck(staffDetails);
     expect(response.redirectPath).toEqual('/onboard-user');
@@ -11,6 +11,7 @@ describe('OnboardChecker', () => {
 
   it('noops-dashboard for inflight onboarding process', () => {
     const staffDetails = {
+      staffid: 'staffid',
       onboardprocessinstanceid: 'id',
     };
     const response = OnboardChecker.onBoardCheck(staffDetails);
@@ -19,6 +20,7 @@ describe('OnboardChecker', () => {
 
   it('authorized redirectPath if staff contains dateofleaving', () => {
     const staffDetails = {
+      staffid: 'staffid',
       dateofleaving: '01/01/2018',
     };
     const response = OnboardChecker.onBoardCheck(staffDetails);

--- a/app/index.jsx
+++ b/app/index.jsx
@@ -88,7 +88,7 @@ const renderApp = App => {
       } catch (error) {
         console.log('Error fetching staffId:', error);
       }
-      return response.data[0].staffid;
+      return response.data[0] ? response.data[0].staffid : null;
     };
 
     const team = teamid && (await fetchTeam());


### PR DESCRIPTION
COP has an API call to get the staff id from the staff details based on the user's email address. This works fine for existing users but new users don't have staff details saved in the db.

The issue with this is that the code is not checking if data is returned from the response before trying to return the staff id and throwing an error for a new user because it's trying to return `staffid` of an undefined value.

This change fixes that by checking if data is returned in the API response before trying to return `staffid` and if not then returning null.

Also updated the unit tests.