### PR TITLE
Make local storage keys user-specific

### DIFF
--- a/app/core/shift/withShiftCheck.jsx
+++ b/app/core/shift/withShiftCheck.jsx
@@ -25,7 +25,7 @@ export default function (ComposedComponent) {
 
     componentDidMount() {
       this.props.resetErrors();
-      let shiftFromLocalStorage = this.secureLocalStorage.get('shift');
+      let shiftFromLocalStorage = this.secureLocalStorage.get(`shift::${this.props.kc.tokenParsed.email}`);
       if (!shiftFromLocalStorage) {
         this.props.fetchActiveShift();
       }
@@ -40,9 +40,9 @@ export default function (ComposedComponent) {
     componentDidUpdate(prevProps, prevState, snapshot) {
       if (!isFetchingShift) {
         if (this.props.hasActiveShift && this.shiftValid(this.props.shift)) {
-          this.secureLocalStorage.set('shift', this.props.shift);
+          this.secureLocalStorage.set(`shift::${this.props.kc.tokenParsed.email}`, this.props.shift);
         } else {
-          this.secureLocalStorage.remove('shift');
+          this.secureLocalStorage.remove(`shift::${this.props.kc.tokenParsed.email}`);
           this.props.history.replace(AppConstants.SHIFT_PATH);
         }
       }
@@ -103,12 +103,18 @@ export default function (ComposedComponent) {
     setHasActiveShift: PropTypes.func.isRequired,
     resetErrors: PropTypes.func.isRequired,
     isFetchingShift: PropTypes.bool,
+    kc: PropTypes.shape({
+      tokenParsed: PropTypes.shape({
+        email: PropTypes.string.isRequired
+      }).isRequired
+    }).isRequired,
     hasActiveShift: PropTypes.bool,
   };
 
   const mapStateToProps = createStructuredSelector({
     hasActiveShift,
     isFetchingShift,
+    kc: state => state.keycloak,
     shift,
   });
 

--- a/app/index.jsx
+++ b/app/index.jsx
@@ -109,7 +109,7 @@ const renderApp = App => {
       teamid,
     };
     secureLocalStorage.set(`staffContext::${email}`, staffDetails);
-    secureLocalStorage.set('extendedStaffDetails', {
+    secureLocalStorage.set(`extendedStaffDetails::${email}`, {
       delegateEmails,
       email,
       linemanagerEmail,

--- a/app/pages/cases/case-actions/components/CaseAction.jsx
+++ b/app/pages/cases/case-actions/components/CaseAction.jsx
@@ -77,7 +77,7 @@ class CaseAction extends React.Component {
         givenName: kc.tokenParsed.given_name,
         familyName: kc.tokenParsed.family_name
       },
-      shiftDetailsContext: secureLocalStorage.get('shift'),
+      shiftDetailsContext: secureLocalStorage.get(`shift::${kc.tokenParsed.email}`),
       staffDetailsDataContext: secureLocalStorage.get(`staffContext::${kc.tokenParsed.email}`),
       extendedStaffDetailsContext: secureLocalStorage.get(`extendedStaffDetails::${kc.tokenParsed.email}`),
       environmentContext: {

--- a/app/pages/cases/case-actions/components/CaseAction.jsx
+++ b/app/pages/cases/case-actions/components/CaseAction.jsx
@@ -79,7 +79,7 @@ class CaseAction extends React.Component {
       },
       shiftDetailsContext: secureLocalStorage.get('shift'),
       staffDetailsDataContext: secureLocalStorage.get(`staffContext::${kc.tokenParsed.email}`),
-      extendedStaffDetailsContext: secureLocalStorage.get('extendedStaffDetails'),
+      extendedStaffDetailsContext: secureLocalStorage.get(`extendedStaffDetails::${kc.tokenParsed.email}`),
       environmentContext: {
         referenceDataUrl: appConfig.apiRefUrl,
         workflowUrl: appConfig.workflowServiceUrl,

--- a/app/pages/dashboard/components/DashboardTitle.jsx
+++ b/app/pages/dashboard/components/DashboardTitle.jsx
@@ -28,7 +28,7 @@ class DashboardTitle extends React.Component {
 
   endShift(e) {
     e.preventDefault();
-    this.secureLocalStorage.remove('shift');
+    this.secureLocalStorage.remove(`shift::${this.props.kc.tokenParsed.email}`);
     this.props.endShift();
   }
 

--- a/app/pages/forms/start/components/FormsStartPage.jsx
+++ b/app/pages/forms/start/components/FormsStartPage.jsx
@@ -82,20 +82,20 @@ export class ProcessStartPage extends React.Component {
     this.props.clearProcessDefinition();
     if (this.props.processDefinition.getIn(['process-definition', 'id'])) {
       this.secureLocalStorage.remove(
-        this.props.processDefinition.getIn(['process-definition', 'id']),
+        `${this.props.processDefinition.getIn(['process-definition', 'id'])}::${this.props.kc.tokenParsed.email}`
       );
     }
   }
 
   handleCustomEvent = event => {
-    const { history, processDefinition: pd } = this.props;
+    const { history, kc, processDefinition: pd } = this.props;
     switch (event.type) {
       case 'cancel':
-        this.secureLocalStorage.remove(pd.getIn(['process-definition', 'id']));
+        this.secureLocalStorage.remove(`${pd.getIn(['process-definition', 'id'])}::${kc.tokenParsed.email}`);
         history.replace(AppConstants.DASHBOARD_PATH);
         break;
       case 'cancel-form':
-        this.secureLocalStorage.remove(pd.getIn(['process-definition', 'id']));
+        this.secureLocalStorage.remove(`${pd.getIn(['process-definition', 'id'])}::${kc.tokenParsed.email}`);
         history.replace(AppConstants.FORMS_PATH);
         break;
       case 'save-draft':
@@ -120,7 +120,7 @@ export class ProcessStartPage extends React.Component {
         window.scrollTo(0, 0);
         this.form.formio.emit('submitDone');
         this.secureLocalStorage.remove(
-          this.props.processDefinition.getIn(['process-definition', 'id']),
+          `${this.props.processDefinition.getIn(['process-definition', 'id'])}::${user}`
         );
         this.props.log([
           {
@@ -159,7 +159,7 @@ export class ProcessStartPage extends React.Component {
         const submission = this.form.formio.submission
           ? this.form.formio.submission
           : this.secureLocalStorage.get(
-              this.props.processDefinition.getIn(['process-definition', 'id']),
+              `${this.props.processDefinition.getIn(['process-definition', 'id'])}::${user}`
             );
         this.form.formio.emit('error');
         this.form.formio.emit('change', submission);
@@ -180,6 +180,7 @@ export class ProcessStartPage extends React.Component {
   render() {
     const {
       form,
+      kc,
       loadingForm,
       noBackLink,
       processDefinition,
@@ -291,7 +292,7 @@ export class ProcessStartPage extends React.Component {
                     }}
                     dataChange={instance => {
                       this.secureLocalStorage.set(
-                        processDefinition.getIn(['process-definition', 'id']),
+                        `${processDefinition.getIn(['process-definition', 'id'])}::${kc.tokenParsed.email}`,
                         instance.data,
                       );
                     }}
@@ -328,6 +329,11 @@ ProcessStartPage.propTypes = {
   clearProcessDefinition: PropTypes.func.isRequired,
   history: PropTypes.shape({
     replace: PropTypes.func.isRequired,
+  }).isRequired,
+  kc: PropTypes.shape({
+    tokenParsed: PropTypes.shape({
+      email: PropTypes.string.isRequired,
+    }).isRequired,
   }).isRequired,
   submit: PropTypes.func,
   processDefinition: ImmutablePropTypes.map,

--- a/app/pages/forms/start/components/StartForm.jsx
+++ b/app/pages/forms/start/components/StartForm.jsx
@@ -63,7 +63,7 @@ class StartForm extends React.Component {
         if (!submission.extendedStaffDetailsContext) {
             submission = {
                 ...submission,
-              extendedStaffDetailsContext: secureLocalStorage.get('extendedStaffDetails')
+              extendedStaffDetailsContext: secureLocalStorage.get(`extendedStaffDetails::${kc.tokenParsed.email}`)
             };
         }
         if (!submission.environmentContext) {

--- a/app/pages/forms/start/components/StartForm.jsx
+++ b/app/pages/forms/start/components/StartForm.jsx
@@ -51,7 +51,7 @@ class StartForm extends React.Component {
 
         if (!submission.shiftDetailsContext) {
             submission = {
-                ...submission, shiftDetailsContext: secureLocalStorage.get('shift')
+                ...submission, shiftDetailsContext: secureLocalStorage.get(`shift::${kc.tokenParsed.email}`)
             }
         }
         if (!submission.staffDetailsDataContext) {

--- a/app/pages/forms/start/components/StartForm.jsx
+++ b/app/pages/forms/start/components/StartForm.jsx
@@ -33,7 +33,7 @@ class StartForm extends React.Component {
             dataChange, formReference, handleSubmit, onCustomEvent, appConfig,
             startForm, kc, processDefinition
         } = this.props;
-        let submission = secureLocalStorage.get(processDefinition.getIn(['process-definition', 'id'])) || {};
+        let submission = secureLocalStorage.get(`${processDefinition.getIn(['process-definition', 'id'])}::${kc.tokenParsed.email}`) || {};
         submission = {
             ...submission, keycloakContext: {
                 accessToken: kc.token,

--- a/app/pages/reports/components/PowerBIReport.jsx
+++ b/app/pages/reports/components/PowerBIReport.jsx
@@ -18,7 +18,7 @@ export class PowerBIReport extends Component {
   }
 
   componentDidMount() {
-    const { apiRefUrl, accessToken, embedUrl, id, token } = this.props;
+    const { apiRefUrl, accessToken, embedUrl, id, kc } = this.props;
 
     const powerBIBranchNames = [
       'Central',
@@ -33,12 +33,12 @@ export class PowerBIReport extends Component {
 
     const {
       team: { branchid: branchId } = {},
-    } = secureLocalStorage.get('shift');
+    } = secureLocalStorage.get(`shift::${kc.tokenParsed.email}`);
 
     axios({
       method: 'get',
       url: `${apiRefUrl}/v2/entities/branch?filter=id=eq.${branchId}`,
-      headers: { Authorization: `Bearer ${token}` },
+      headers: { Authorization: `Bearer ${kc.token}` },
     })
       .then(({ data }) => {
         const branchName = data.data.length && data.data[0].name;
@@ -144,13 +144,18 @@ PowerBIReport.propTypes = {
   apiRefUrl: PropTypes.string.isRequired,
   embedUrl: PropTypes.string.isRequired,
   id: PropTypes.string.isRequired,
-  token: PropTypes.string.isRequired,
+  kc: PropTypes.shape({
+    token: PropTypes.string.isRequired,
+    tokenParsed: PropTypes.shape({
+      email: PropTypes.string.isRequired,
+    }).isRequired,
+  }).isRequired,
   useMobileLayout: PropTypes.bool.isRequired,
 };
 
 export default connect(state => {
   return {
-    token: state.keycloak.token,
+    kc: state.keycloak,
     apiRefUrl: state.appConfig.apiRefUrl,
   };
 })(PowerBIReport);

--- a/app/pages/reports/components/PowerBIReport.test.jsx
+++ b/app/pages/reports/components/PowerBIReport.test.jsx
@@ -16,7 +16,12 @@ describe('PowerBIReport', () => {
     id: 'abc',
     name: 'Power BI Report',
     useMobileLayout: true,
-    token: 'xyz',
+    kc: {
+      token: 'xyz',
+      tokenParsed: {
+        email: 'test@example.com',
+      },
+    },
   };
 
   it('renders a PowerBIReport', () => {

--- a/app/pages/shift/components/ShiftForm.jsx
+++ b/app/pages/shift/components/ShiftForm.jsx
@@ -82,7 +82,7 @@ export default class ShiftForm extends React.Component {
                     familyName: kc.tokenParsed.family_name
                 },
                 staffDetailsDataContext: staffDetails,
-                extendedStaffDetailsContext: secureLocalStorage.get('extendedStaffDetails'),
+                extendedStaffDetailsContext: secureLocalStorage.get(`extendedStaffDetails::${kc.tokenParsed.email}`),
                 environmentContext: {
                     referenceDataUrl: appConfig.apiRefUrl,
                     workflowUrl: appConfig.workflowServiceUrl,

--- a/app/pages/shift/components/ShiftPage.jsx
+++ b/app/pages/shift/components/ShiftPage.jsx
@@ -37,7 +37,7 @@ export class ShiftPage extends React.Component {
       if (this.props.submittingActiveShift !== prevProps.submittingActiveShift && !this.props.submittingActiveShift) {
           if (this.form && this.form.formio) {
               if (this.props.activeShiftSuccess) {
-                  this.secureLocalStorage.set('shift', this.props.shift);
+                  this.secureLocalStorage.set(`shift::${this.props.kc.tokenParsed.email}`, this.props.shift);
                   this.form.formio.emit('submitDone');
                   this.props.history.replace('/dashboard');
                 } else {
@@ -93,6 +93,11 @@ ShiftPage.propTypes = {
   fetchShiftForm: PropTypes.func.isRequired,
   fetchActiveShift: PropTypes.func.isRequired,
   isFetchingShift: PropTypes.bool,
+  kc: PropTypes.shape({
+    tokenParsed: PropTypes.shape({
+      email: PropTypes.string.isRequired
+    }).isRequired
+  }).isRequired,
   shift: ImmutablePropTypes.map,
   unauthorised: PropTypes.bool,
 };

--- a/app/pages/task/form/components/CompleteTaskForm.jsx
+++ b/app/pages/task/form/components/CompleteTaskForm.jsx
@@ -84,7 +84,7 @@ export class CompleteTaskForm extends React.Component {
                 window.scrollTo(0, 0);
                 Formio.clearCache();
                 if (taskId) {
-                    secureLocalStorage.remove(taskId);
+                    secureLocalStorage.remove(`${taskId}::${user}`);
                 }
                 if (this.props.submissionResponse && this.props.submissionResponse.task) {
                     const {task} = this.props.submissionResponse;

--- a/app/pages/task/form/components/TaskForm.jsx
+++ b/app/pages/task/form/components/TaskForm.jsx
@@ -102,10 +102,10 @@ export default class TaskForm extends React.Component {
       }
 
     }
-    if (secureLocalStorage.get(task.get('id'))) {
+    if (secureLocalStorage.get(`${task.get('id')}::${kc.tokenParsed.email}`)) {
       submission.data = {
         ...submission.data,
-        ...secureLocalStorage.get(task.get('id'))
+        ...secureLocalStorage.get(`${task.get('id')}::${kc.tokenParsed.email}`)
       }
     }
     submission.data = {
@@ -189,7 +189,7 @@ export default class TaskForm extends React.Component {
           }
         }}
         onChange={instance => {
-          secureLocalStorage.set(task.get('id'),
+          secureLocalStorage.set(`${task.get('id')}::${kc.tokenParsed.email}`,
               _.omit(instance.data,
                   ['keycloakContext',
                    'shiftDetailsContext',

--- a/app/pages/task/form/components/TaskForm.jsx
+++ b/app/pages/task/form/components/TaskForm.jsx
@@ -122,7 +122,7 @@ export default class TaskForm extends React.Component {
         realm: kc.realm,
         groups: kc.tokenParsed.groups,
       },
-      shiftDetailsContext: secureLocalStorage.get('shift'),
+      shiftDetailsContext: secureLocalStorage.get(`shift::${kc.tokenParsed.email}`),
       staffDetailsDataContext: secureLocalStorage.get(
         `staffContext::${kc.tokenParsed.email}`,
       ),

--- a/app/pages/task/form/components/TaskForm.jsx
+++ b/app/pages/task/form/components/TaskForm.jsx
@@ -126,9 +126,7 @@ export default class TaskForm extends React.Component {
       staffDetailsDataContext: secureLocalStorage.get(
         `staffContext::${kc.tokenParsed.email}`,
       ),
-      extendedStaffDetailsContext: secureLocalStorage.get(
-        'extendedStaffDetails',
-      ),
+      extendedStaffDetailsContext: secureLocalStorage.get(`extendedStaffDetails::${kc.tokenParsed.email}`),
       environmentContext: {
         referenceDataUrl: appConfig.apiRefUrl,
         workflowUrl: appConfig.workflowServiceUrl,


### PR DESCRIPTION
In the case that multiple users are using the same browser we would not want them to retrieve or preload each other's data.