### PR TITLE
Make roles available on keycloakContext object

### DIFF
--- a/app/pages/forms/start/components/FormsStartPage.jsx
+++ b/app/pages/forms/start/components/FormsStartPage.jsx
@@ -333,6 +333,9 @@ ProcessStartPage.propTypes = {
   kc: PropTypes.shape({
     tokenParsed: PropTypes.shape({
       email: PropTypes.string.isRequired,
+      realm_access: PropTypes.shape({
+        roles: PropTypes.arrayOf(PropTypes.string).isRequired,
+      }).isRequired,
     }).isRequired,
   }).isRequired,
   submit: PropTypes.func,

--- a/app/pages/forms/start/components/FormsStartPage.test.jsx
+++ b/app/pages/forms/start/components/FormsStartPage.test.jsx
@@ -124,6 +124,7 @@ describe('Submit a form page', () => {
           email: 'email',
           given_name: 'given_name',
           family_name: 'familyName',
+          realm_access: { roles: ['role'] },
         },
       },
       match: {
@@ -175,6 +176,7 @@ describe('Submit a form page', () => {
       kc: {
         tokenParsed: {
           email: 'email',
+          realm_access: { roles: ['role'] },
         },
       },
       form: null,
@@ -221,6 +223,7 @@ describe('Submit a form page', () => {
       kc: {
         tokenParsed: {
           email: 'email',
+          realm_access: { roles: ['role'] },
         },
       },
       form: null,
@@ -262,6 +265,7 @@ describe('Submit a form page', () => {
       kc: {
         tokenParsed: {
           email: 'email',
+          realm_access: { roles: ['role'] },
         },
       },
       loadingForm: false,
@@ -308,6 +312,7 @@ describe('Submit a form page', () => {
       kc: {
         tokenParsed: {
           email: 'email',
+          realm_access: { roles: ['role'] },
         },
       },
       appConfig: {
@@ -362,6 +367,7 @@ describe('Submit a form page', () => {
       kc: {
         tokenParsed: {
           email: 'email',
+          realm_access: { roles: ['role'] },
         },
       },
       loadingForm: false,
@@ -439,6 +445,7 @@ describe('Submit a form page', () => {
       kc: {
         tokenParsed: {
           email: 'email',
+          realm_access: { roles: ['role'] },
         },
       },
     };

--- a/app/pages/forms/start/components/StartForm.jsx
+++ b/app/pages/forms/start/components/StartForm.jsx
@@ -46,6 +46,7 @@ class StartForm extends React.Component {
                 subject: kc.subject,
                 url: kc.authServerUrl,
                 realm: kc.realm,
+                roles: kc.tokenParsed.realm_access.roles,
             }
         };
 

--- a/app/pages/forms/start/components/__snapshots__/FormsStartPage.test.jsx.snap
+++ b/app/pages/forms/start/components/__snapshots__/FormsStartPage.test.jsx.snap
@@ -145,6 +145,11 @@ exports[`Submit a form page renders the form and process definition 1`] = `
               Object {
                 "tokenParsed": Object {
                   "email": "email",
+                  "realm_access": Object {
+                    "roles": Array [
+                      "role",
+                    ],
+                  },
                 },
               }
             }

--- a/app/pages/task/form/components/TaskForm.jsx
+++ b/app/pages/task/form/components/TaskForm.jsx
@@ -121,6 +121,7 @@ export default class TaskForm extends React.Component {
         url: kc.authServerUrl,
         realm: kc.realm,
         groups: kc.tokenParsed.groups,
+        roles: kc.tokenParsed.realm_access.roles,
       },
       shiftDetailsContext: secureLocalStorage.get(`shift::${kc.tokenParsed.email}`),
       staffDetailsDataContext: secureLocalStorage.get(

--- a/app/pages/task/form/components/TaskForm.test.jsx
+++ b/app/pages/task/form/components/TaskForm.test.jsx
@@ -25,7 +25,8 @@ describe('TaskForm Component', () => {
           family_name: 'test',
           given_name: 'name',
           session_state: 'state',
-          groups: ['/group/one', '/group/two']
+          groups: ['/group/one', '/group/two'],
+          realm_access: { roles: ['role'] },
         },
       },
       onCustomEvent: jest.fn(),

--- a/app/pages/task/form/components/__snapshots__/TaskForm.test.jsx.snap
+++ b/app/pages/task/form/components/__snapshots__/TaskForm.test.jsx.snap
@@ -139,6 +139,11 @@ exports[`TaskForm Component matches snapshot 1`] = `
               "/group/one",
               "/group/two",
             ],
+            "realm_access": Object {
+              "roles": Array [
+                "role",
+              ],
+            },
             "session_state": "state",
           },
           "url": "http://localhost",
@@ -179,6 +184,9 @@ exports[`TaskForm Component matches snapshot 1`] = `
           ],
           "realm": "cop-test",
           "refreshToken": undefined,
+          "roles": Array [
+            "role",
+          ],
           "sessionId": "state",
           "subject": "d3eb0456-1b82-4c64-a987-7201d9ce9312",
           "url": undefined,


### PR DESCRIPTION
In UI1 here, unlike in UI2, the user's roles are not currently added to the `keycloakContext` object. We want them be, however, so that we can check them for conditional validation in the COVID Compliance Checks form.

This PR accordingly grabs the `roles` array from the `tokenParsed.realm_access` object and adds it to the `keycloakContext` object. Note that both the `realm_access` object and the `roles` array are expected to be present (in PropTypes).