### PR TITLE
Use customValidation instead of beforeSubmit hook

### DIFF
--- a/app/pages/forms/start/components/StartForm.jsx
+++ b/app/pages/forms/start/components/StartForm.jsx
@@ -86,7 +86,7 @@ class StartForm extends React.Component {
                 beforeCancel: (...args) => {
                     this.handleCancel(args);
                 },
-                beforeSubmit: (submission, next) => {
+                customValidation: (submission, next) => {
                     const toDelete = ['keycloakContext', 'staffDetailsDataContext'];
                     toDelete.forEach(key => {
                         delete submission.data[key];

--- a/app/pages/shift/components/ShiftForm.jsx
+++ b/app/pages/shift/components/ShiftForm.jsx
@@ -51,7 +51,7 @@ export default class ShiftForm extends React.Component {
                 beforeCancel: (...args) => {
                     this.handleCancel(args);
                 },
-                beforeSubmit: (submission, next) => {
+                customValidation: (submission, next) => {
                     const toDelete = ['keycloakContext', 'staffDetailsDataContext','environmentContext'];
                     toDelete.forEach(key => {
                         delete submission.data[key];

--- a/app/pages/task/form/components/TaskForm.jsx
+++ b/app/pages/task/form/components/TaskForm.jsx
@@ -63,7 +63,7 @@ export default class TaskForm extends React.Component {
         beforeCancel: (...args) => {
           this.handleCancel(args);
         },
-        beforeSubmit: (submission, next) => {
+        customValidation: (submission, next) => {
           [
             'keycloakContext',
             'staffDetailsDataContext',

--- a/app/pages/task/form/components/__snapshots__/TaskForm.test.jsx.snap
+++ b/app/pages/task/form/components/__snapshots__/TaskForm.test.jsx.snap
@@ -151,7 +151,7 @@ exports[`TaskForm Component matches snapshot 1`] = `
       },
       "hooks": Object {
         "beforeCancel": [Function],
-        "beforeSubmit": [Function],
+        "customValidation": [Function],
       },
       "i18n": Object {
         "en": Object {


### PR DESCRIPTION
If we try to perform validation that depends on certain context objects which are removed when the form is submitted, we run into a problem when the `beforeSubmit` hook is used in that they are removed before the validation occurs. If we instead use the `customValidation` hook then these objects are removed _after_ validation occurs, getting around the problem.