### PR TITLE
Cop 6739 operating mandate append record

### DIFF
--- a/app/pages/cases/case-actions/components/CaseAction.jsx
+++ b/app/pages/cases/case-actions/components/CaseAction.jsx
@@ -75,7 +75,8 @@ class CaseAction extends React.Component {
         sessionId: kc.tokenParsed.session_state,
         email: kc.tokenParsed.email,
         givenName: kc.tokenParsed.given_name,
-        familyName: kc.tokenParsed.family_name
+        familyName: kc.tokenParsed.family_name,
+        groups: kc.tokenParsed.groups
       },
       shiftDetailsContext: secureLocalStorage.get(`shift::${kc.tokenParsed.email}`),
       staffDetailsDataContext: secureLocalStorage.get(`staffContext::${kc.tokenParsed.email}`),

--- a/app/pages/cases/case-actions/components/CaseAction.test.jsx
+++ b/app/pages/cases/case-actions/components/CaseAction.test.jsx
@@ -12,6 +12,7 @@ describe('CaseAction', () => {
     beforeEach(() => {
         store = configureStore()({
             'case-action-page': new Map({}),
+            'case-page': new Map({}),
         });
         props = {
             appConfig: {
@@ -62,6 +63,7 @@ describe('CaseAction', () => {
             'case-action-page': new Map({
                 loadingActionForm: true
             }),
+            'case-page': new Map({}),
         });
         props = {
             ...props,
@@ -87,6 +89,7 @@ describe('CaseAction', () => {
                 loadingActionForm: false,
                 actionForm: null
             }),
+            'case-page': new Map({}),
         });
         props = {
             ...props,
@@ -114,6 +117,7 @@ describe('CaseAction', () => {
                 actionForm: fixtures,
                 executingAction: true
             }),
+            'case-page': new Map({}),
         });
         props = {
             ...props,
@@ -141,6 +145,7 @@ describe('CaseAction', () => {
                 actionForm: fixtures,
                 executingAction: false,
             }),
+            'case-page': new Map({}),
             keycloak: props.kc,
             appConfig: props.appConfig
         });
@@ -160,5 +165,40 @@ describe('CaseAction', () => {
         );
         const formio = wrapper.find('Form');
         expect(formio.exists()).toEqual(true);
+    });
+
+    it('sets the latest form data path if there is a single form and a single process instance', async () => {
+      const processInstances = [{
+        formReferences: [{
+          name: 'form1',
+          dataPath: 'form1DataPath1'
+        }]
+      }];
+      const wrapper = shallow(<CaseAction.WrappedComponent />);
+      const path = wrapper.dive().instance().latestFormDataPath(processInstances, 'form1');
+      expect(path).toEqual('form1DataPath1');
+    });
+
+    it('sets the latest form data path if there are multiple forms and multiple process instances', async () => {
+      const processInstances = [{
+        formReferences: [{
+          name: 'form1',
+          dataPath: 'form1DataPath1'
+        }, {
+          name: 'form2',
+          dataPath: 'form2DataPath1'
+        }]
+      }, {
+        formReferences: [{
+          name: 'form1',
+          dataPath: 'form1DataPath2'
+        }, {
+          name: 'form2',
+          dataPath: 'form2DataPath2'
+        }]
+      }];
+      const wrapper = shallow(<CaseAction.WrappedComponent />);
+      const path = wrapper.dive().instance().latestFormDataPath(processInstances, 'form1');
+      expect(path).toEqual('form1DataPath2');
     });
 });

--- a/app/pages/cases/case-actions/components/CaseAction.test.jsx
+++ b/app/pages/cases/case-actions/components/CaseAction.test.jsx
@@ -28,6 +28,7 @@ describe('CaseAction', () => {
                     session_state: 'state',
                     line_manager_email: null,
                     delegate_email: null,
+                    groups: ['/Group_One', '/Group_Two'],
                 },
             },
             caseDetails: {

--- a/app/pages/cases/case-actions/components/CaseActions.test.jsx
+++ b/app/pages/cases/case-actions/components/CaseActions.test.jsx
@@ -8,6 +8,7 @@ import { Provider } from 'react-redux';
 import CaseActions from './CaseActions';
 import caseActions from '../index';
 import fixtures from './fixtures';
+import casePageActions from '../../index';
 
 describe('CaseActions', () => {
   let props;
@@ -93,7 +94,10 @@ describe('CaseActions', () => {
     const history = createMemoryHistory('/case');
 
     const store = createStore(
-      combineReducers({ [caseActions.NAME]: caseActions.reducer }),
+      combineReducers({
+        [caseActions.NAME]: caseActions.reducer,
+        [casePageActions.NAME]: casePageActions.reducer
+      }),
       {},
     );
 


### PR DESCRIPTION
In Operating Mandate we need to be able to pre-populate the initial request form in the Case Actions in Case View with the latest data so that the user can add additional information to the request.

This change does that by adding a `latestFormDataPath()` method which gets the latest form data path, which is the file path of the data in the S3 bucket, and if this exists the it is used to fetch the data. This method is called when the component mounts and when it updates to ensure that we load the data if necessary when the first tab loads and when subsequent tabs are selected.

The data is only pre-populated in the form if the field `calculatedValue` uses the new `formSubmissionData` object to set the field value, for example `value = data.formSubmissionData.fieldApiKey` so forms won't get unintentionally pre-populated. 