### PR TITLE
COP-6739 - Operating Mandate Append Record

### DIFF
--- a/app/pages/cases/case-actions/components/CaseAction.jsx
+++ b/app/pages/cases/case-actions/components/CaseAction.jsx
@@ -51,7 +51,6 @@ class CaseAction extends React.Component {
     const {
       caseDetails: { businessKey, processInstances = [] } = {},
       getFormSubmissionData,
-      resetForm,
       selectedAction: { process: currProcess, process: { formKey } = {} } = {}
     } = this.props;
 
@@ -60,9 +59,6 @@ class CaseAction extends React.Component {
     if (currProcess['process-definition'].key !== prevProcess['process-definition'].key) {
       this.props.clearActionResponse();
       this.props.fetchActionForm(formKey);
-
-      resetForm();
-
       const latestFormDataPath = this.latestFormDataPath(processInstances, formKey);
 
       if (latestFormDataPath) {
@@ -84,6 +80,7 @@ class CaseAction extends React.Component {
     if (this.timer) {
       clearTimeout(this.timer);
     }
+    this.props.resetForm();
   }
 
   render() {
@@ -106,7 +103,7 @@ class CaseAction extends React.Component {
       return <div id="submittingAction">Submitting action...</div>
     }
 
-    const submission = {
+    let submission = {
       caseDetails,
       selectedAction,
       keycloakContext: {
@@ -127,9 +124,16 @@ class CaseAction extends React.Component {
         operationalDataUrl: appConfig.operationalDataUrl,
         privateUiUrl: window.location.origin,
         attachmentServiceUrl: appConfig.attachmentServiceUrl
-      },
-      formSubmissionData
+      }
     };
+
+    const isPrepopulated = actionForm.components.find(c => c.key === 'caseActionPrepopulate');
+    if (isPrepopulated) {
+      submission = {
+        ...submission,
+        ...formSubmissionData
+      }
+    }
 
     this.formioInterpolator.interpolate(actionForm, submission);
     return (

--- a/app/pages/cases/case-actions/components/CaseActions.jsx
+++ b/app/pages/cases/case-actions/components/CaseActions.jsx
@@ -8,6 +8,7 @@ import CaseAction from "./CaseAction";
 import withLog from "../../../../core/error/component/withLog";
 import {setSelectedAction} from "../actions";
 import {selectedAction} from "../selectors";
+import {setSelectedFormReference} from '../../actions';
 
 class CaseActions extends React.Component {
 
@@ -20,7 +21,12 @@ class CaseActions extends React.Component {
     }
 
     render() {
-        const {caseDetails, selectedAction, setSelectedAction} = this.props;
+        const {
+          caseDetails,
+          selectedAction,
+          setSelectedAction,
+          setSelectedFormReference
+        } = this.props;
 
         return (
           <div className="govuk-grid-row govuk-card" id="caseActions">
@@ -63,6 +69,7 @@ class CaseActions extends React.Component {
                                                   onClick={event => {
                                                     event.preventDefault();
                                                     setSelectedAction(action);
+                                                    setSelectedFormReference(null);
                                                 }}
                                                 > {action.process['process-definition'].name}
                                                 </a>
@@ -109,7 +116,10 @@ CaseActions.propTypes = {
         }))
     })
 };
-const mapDispatchToProps = dispatch => bindActionCreators({setSelectedAction}, dispatch);
+const mapDispatchToProps = dispatch => bindActionCreators({
+  setSelectedAction,
+  setSelectedFormReference
+}, dispatch);
 
 export default withRouter(connect(state => {
     return {

--- a/app/pages/cases/components/CaseDetailsPanel.jsx
+++ b/app/pages/cases/components/CaseDetailsPanel.jsx
@@ -15,6 +15,7 @@ import withLog from "../../../core/error/component/withLog";
 import CaseActions from "../case-actions/components/CaseActions";
 import CaseMetrics from "./CaseMetrics";
 import CaseAttachments from "./CaseAttachments";
+import {setSelectedAction} from '../case-actions/actions';
 
 class CaseDetailsPanel extends React.Component {
     constructor(props) {
@@ -221,6 +222,7 @@ class CaseDetailsPanel extends React.Component {
 
                                                                                         if ((!selectedFormReference || (keyFromSelectedReference && keyFromSelectedReference !== key))) {
                                                                                             this.props.setSelectedFormReference(form)
+                                                                                            this.props.setSelectedAction(this.props.caseDetails.actions[this.props.caseDetails.actions.length - 1]);
                                                                                         } else {
                                                                                             this.props.setSelectedFormReference(null)
                                                                                         }
@@ -291,6 +293,7 @@ class CaseDetailsPanel extends React.Component {
 
             const mapDispatchToProps = dispatch => bindActionCreators({
             getFormVersion,
+            setSelectedAction,
             setSelectedFormReference,
             setProcessStartSort
         }, dispatch);


### PR DESCRIPTION
These changes improve the append a record functionality that is used in Case View for Operating Mandate.

1. Update CaseAction to prepopulate the form if the form has a flag set. We're now setting a flag in the form to determine if the Case Action is prepopulated rather than relying on the data being available in `data.formSubmissionData` as the latter was proving too unreliable.

2.  Update CaseActions to close the form view if a Case Action tab is selected. We need to ensure that we don;t have cross-contamination of the data in the forms in the Case Action and the form view below so when the Case Action tab is selected the form below is reset.

3.  Update CaseDetailsPanel to reset the Case Action tab if a form view is opened. Similarly to above, we want to avoid cross-contamination of the data in the Case Action with the form in the form view below so when the form in the form view is opened the Case Action is reset so that the Update Request tab needs to be explicitly clicked which reloads the correct data. 



